### PR TITLE
Add points

### DIFF
--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -217,7 +217,8 @@ export default class Example extends Component<
       },
 
       // Can customize editing points props
-      getEditingPointColor: () => [0xff, 0x80, 0x00, 0xff]
+      getEditHandlePointColor: handle =>
+        handle.type === 'existing' ? [0xff, 0x80, 0x00, 0xff] : [0x0, 0x0, 0x0, 0x80]
     });
 
     return (

--- a/src/lib/editable-feature-collection.js
+++ b/src/lib/editable-feature-collection.js
@@ -123,11 +123,24 @@ export class EditableFeatureCollection {
       case 'MultiPoint':
       case 'LineString':
         // positions are nested 1 level
-        positions = geometry.coordinates.map((position, index) => ({
-          position,
-          positionIndexes: [index],
-          handleType: 'existing'
-        }));
+        for (let i = 0; i < geometry.coordinates.length; i++) {
+          const position = geometry.coordinates[i];
+          positions.push({
+            position,
+            positionIndexes: [i],
+            handleType: 'existing'
+          });
+
+          if (i < geometry.coordinates.length - 1) {
+            // add intermediate position after every position except the last one
+            const nextPosition = geometry.coordinates[i + 1];
+            positions.push({
+              position: getIntermediatePosition(position, nextPosition),
+              positionIndexes: [i],
+              handleType: 'intermediate'
+            });
+          }
+        }
         break;
       case 'Polygon':
       case 'MultiLineString':
@@ -256,4 +269,15 @@ function immutablyRemovePosition(
     ),
     ...coordinates.slice(positionIndexes[0] + 1)
   ];
+}
+
+function getIntermediatePosition(
+  position1: Array<number>,
+  position2: Array<number>
+): Array<number> {
+  const intermediatePosition = [];
+  for (let dimension = 0; dimension < position1.length; dimension++) {
+    intermediatePosition.push((position1[dimension] + position2[dimension]) / 2.0);
+  }
+  return intermediatePosition;
 }

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -290,10 +290,23 @@ export default class EditableGeoJsonLayer extends CompositeLayer {
     const pickedPoint = allPicked.find(picked => picked.isEditingHandle);
     if (pickedPoint) {
       if (pickedPoint.object.type === 'intermediate') {
-        console.log('TODO: implement adding intermediate points', pickedPoint.object); // eslint-disable-line
-      } else {
-        this.setState({ pointerDownPosition: pickedPoint, pointerDownCoords: pointerCoords });
+        const { position, positionIndexes } = pickedPoint.object;
+        const { selectedFeatureIndex } = this.props;
+
+        const updatedData = this.state.editableFeatureCollection
+          .addPosition(selectedFeatureIndex, positionIndexes, position)
+          .getObject();
+
+        (this.props.onEdit || (() => {}))({
+          data: updatedData,
+          editType: 'addposition',
+          featureIndex: selectedFeatureIndex,
+          positionIndexes,
+          position
+        });
       }
+
+      this.setState({ pointerDownPosition: pickedPoint, pointerDownCoords: pointerCoords });
     }
   }
 

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -299,7 +299,7 @@ export default class EditableGeoJsonLayer extends CompositeLayer {
 
         (this.props.onEdit || (() => {}))({
           data: updatedData,
-          editType: 'addposition',
+          editType: 'addintermediateposition',
           featureIndex: selectedFeatureIndex,
           positionIndexes,
           position

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -8,7 +8,8 @@ const DEFAULT_LINE_COLOR = [0x0, 0x0, 0x0, 0xff];
 const DEFAULT_FILL_COLOR = [0x0, 0x0, 0x0, 0x90];
 const DEFAULT_SELECTED_LINE_COLOR = [0x90, 0x90, 0x90, 0xff];
 const DEFAULT_SELECTED_FILL_COLOR = [0x90, 0x90, 0x90, 0x90];
-const DEFAULT_EDITING_POINT_COLOR = [0x0, 0x0, 0x0, 0xff];
+const DEFAULT_EDITING_EXISTING_POINT_COLOR = [0xc0, 0x0, 0x0, 0xff];
+const DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR = [0x0, 0x0, 0x0, 0x80];
 
 const defaultProps = {
   pickable: true,
@@ -32,11 +33,14 @@ const defaultProps = {
   getLineWidth: f => (f && f.properties && f.properties.lineWidth) || 1,
 
   // Editing handles
-  editingPointRadiusScale: 1,
-  editingPointRadiusMinPixels: 4,
-  editingPointRadiusMaxPixels: Number.MAX_SAFE_INTEGER,
-  getEditingPointColor: () => DEFAULT_EDITING_POINT_COLOR,
-  getEditingPointRadius: () => 3
+  editHandlePointRadiusScale: 1,
+  editHandlePointRadiusMinPixels: 4,
+  editHandlePointRadiusMaxPixels: Number.MAX_SAFE_INTEGER,
+  getEditHandlePointColor: handle =>
+    handle.type === 'existing'
+      ? DEFAULT_EDITING_EXISTING_POINT_COLOR
+      : DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR,
+  getEditHandlePointRadius: handle => (handle.type === 'existing' ? 5 : 3)
 };
 
 // Minimum number of pixels the pointer must move from the original pointer down to be considered dragging
@@ -152,11 +156,11 @@ export default class EditableGeoJsonLayer extends CompositeLayer {
           fp64: this.props.fp64,
 
           // Proxy editing point props
-          radiusScale: this.props.editingPointRadiusScale,
-          radiusMinPixels: this.props.editingPointRadiusMinPixels,
-          radiusMaxPixels: this.props.editingPointRadiusMaxPixels,
-          getColor: this.props.getEditingPointColor,
-          getRadius: this.props.getEditingPointRadius
+          radiusScale: this.props.editHandlePointRadiusScale,
+          radiusMinPixels: this.props.editHandlePointRadiusMinPixels,
+          radiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
+          getColor: this.props.getEditHandlePointColor,
+          getRadius: this.props.getEditHandlePointRadius
         })
       )
     ];
@@ -285,7 +289,11 @@ export default class EditableGeoJsonLayer extends CompositeLayer {
 
     const pickedPoint = allPicked.find(picked => picked.isEditingHandle);
     if (pickedPoint) {
-      this.setState({ pointerDownPosition: pickedPoint, pointerDownCoords: pointerCoords });
+      if (pickedPoint.object.type === 'intermediate') {
+        console.log('TODO: implement adding intermediate points', pickedPoint.object); // eslint-disable-line
+      } else {
+        this.setState({ pointerDownPosition: pickedPoint, pointerDownCoords: pointerCoords });
+      }
     }
   }
 

--- a/src/test/lib/editable-feature-collection.test.js
+++ b/src/test/lib/editable-feature-collection.test.js
@@ -266,7 +266,7 @@ describe('EditableFeatureCollection', () => {
       });
 
       const actual = features.getEditHandles(0);
-      const expected = [{ position: [1, 2], positionIndexes: [] }];
+      const expected = [{ position: [1, 2], positionIndexes: [], handleType: 'existing' }];
 
       expect(actual).toEqual(expected);
     });
@@ -279,8 +279,8 @@ describe('EditableFeatureCollection', () => {
 
       const actual = features.getEditHandles(0);
       const expected = [
-        { position: [1, 2], positionIndexes: [0] },
-        { position: [3, 4], positionIndexes: [1] }
+        { position: [1, 2], positionIndexes: [0], handleType: 'existing' },
+        { position: [3, 4], positionIndexes: [1], handleType: 'existing' }
       ];
 
       expect(actual).toEqual(expected);
@@ -294,16 +294,16 @@ describe('EditableFeatureCollection', () => {
 
       const actual = features.getEditHandles(0);
       const expected = [
-        { position: [-1, -1], positionIndexes: [0, 0] },
-        { position: [1, -1], positionIndexes: [0, 1] },
-        { position: [1, 1], positionIndexes: [0, 2] },
-        { position: [-1, 1], positionIndexes: [0, 3] },
-        { position: [-1, -1], positionIndexes: [0, 4] },
-        { position: [-0.5, -0.5], positionIndexes: [1, 0] },
-        { position: [-0.5, 0.5], positionIndexes: [1, 1] },
-        { position: [0.5, 0.5], positionIndexes: [1, 2] },
-        { position: [0.5, -0.5], positionIndexes: [1, 3] },
-        { position: [-0.5, -0.5], positionIndexes: [1, 4] }
+        { position: [-1, -1], positionIndexes: [0, 0], handleType: 'existing' },
+        { position: [1, -1], positionIndexes: [0, 1], handleType: 'existing' },
+        { position: [1, 1], positionIndexes: [0, 2], handleType: 'existing' },
+        { position: [-1, 1], positionIndexes: [0, 3], handleType: 'existing' },
+        { position: [-1, -1], positionIndexes: [0, 4], handleType: 'existing' },
+        { position: [-0.5, -0.5], positionIndexes: [1, 0], handleType: 'existing' },
+        { position: [-0.5, 0.5], positionIndexes: [1, 1], handleType: 'existing' },
+        { position: [0.5, 0.5], positionIndexes: [1, 2], handleType: 'existing' },
+        { position: [0.5, -0.5], positionIndexes: [1, 3], handleType: 'existing' },
+        { position: [-0.5, -0.5], positionIndexes: [1, 4], handleType: 'existing' }
       ];
 
       expect(actual).toEqual(expected);
@@ -317,8 +317,8 @@ describe('EditableFeatureCollection', () => {
 
       const actual = features.getEditHandles(0);
       const expected = [
-        { position: [1, 2], positionIndexes: [0] },
-        { position: [3, 4], positionIndexes: [1] }
+        { position: [1, 2], positionIndexes: [0], handleType: 'existing' },
+        { position: [3, 4], positionIndexes: [1], handleType: 'existing' }
       ];
 
       expect(actual).toEqual(expected);
@@ -332,10 +332,10 @@ describe('EditableFeatureCollection', () => {
 
       const actual = features.getEditHandles(0);
       const expected = [
-        { position: [1, 2], positionIndexes: [0, 0] },
-        { position: [3, 4], positionIndexes: [0, 1] },
-        { position: [5, 6], positionIndexes: [1, 0] },
-        { position: [7, 8], positionIndexes: [1, 1] }
+        { position: [1, 2], positionIndexes: [0, 0], handleType: 'existing' },
+        { position: [3, 4], positionIndexes: [0, 1], handleType: 'existing' },
+        { position: [5, 6], positionIndexes: [1, 0], handleType: 'existing' },
+        { position: [7, 8], positionIndexes: [1, 1], handleType: 'existing' }
       ];
 
       expect(actual).toEqual(expected);
@@ -349,21 +349,21 @@ describe('EditableFeatureCollection', () => {
 
       const actual = features.getEditHandles(0);
       const expected = [
-        { position: [-1, -1], positionIndexes: [0, 0, 0] },
-        { position: [1, -1], positionIndexes: [0, 0, 1] },
-        { position: [1, 1], positionIndexes: [0, 0, 2] },
-        { position: [-1, 1], positionIndexes: [0, 0, 3] },
-        { position: [-1, -1], positionIndexes: [0, 0, 4] },
-        { position: [-0.5, -0.5], positionIndexes: [0, 1, 0] },
-        { position: [-0.5, 0.5], positionIndexes: [0, 1, 1] },
-        { position: [0.5, 0.5], positionIndexes: [0, 1, 2] },
-        { position: [0.5, -0.5], positionIndexes: [0, 1, 3] },
-        { position: [-0.5, -0.5], positionIndexes: [0, 1, 4] },
-        { position: [2, -1], positionIndexes: [1, 0, 0] },
-        { position: [4, -1], positionIndexes: [1, 0, 1] },
-        { position: [4, 1], positionIndexes: [1, 0, 2] },
-        { position: [2, 1], positionIndexes: [1, 0, 3] },
-        { position: [2, -1], positionIndexes: [1, 0, 4] }
+        { position: [-1, -1], positionIndexes: [0, 0, 0], handleType: 'existing' },
+        { position: [1, -1], positionIndexes: [0, 0, 1], handleType: 'existing' },
+        { position: [1, 1], positionIndexes: [0, 0, 2], handleType: 'existing' },
+        { position: [-1, 1], positionIndexes: [0, 0, 3], handleType: 'existing' },
+        { position: [-1, -1], positionIndexes: [0, 0, 4], handleType: 'existing' },
+        { position: [-0.5, -0.5], positionIndexes: [0, 1, 0], handleType: 'existing' },
+        { position: [-0.5, 0.5], positionIndexes: [0, 1, 1], handleType: 'existing' },
+        { position: [0.5, 0.5], positionIndexes: [0, 1, 2], handleType: 'existing' },
+        { position: [0.5, -0.5], positionIndexes: [0, 1, 3], handleType: 'existing' },
+        { position: [-0.5, -0.5], positionIndexes: [0, 1, 4], handleType: 'existing' },
+        { position: [2, -1], positionIndexes: [1, 0, 0], handleType: 'existing' },
+        { position: [4, -1], positionIndexes: [1, 0, 1], handleType: 'existing' },
+        { position: [4, 1], positionIndexes: [1, 0, 2], handleType: 'existing' },
+        { position: [2, 1], positionIndexes: [1, 0, 3], handleType: 'existing' },
+        { position: [2, -1], positionIndexes: [1, 0, 4], handleType: 'existing' }
       ];
 
       expect(actual).toEqual(expected);

--- a/src/test/lib/editable-feature-collection.test.js
+++ b/src/test/lib/editable-feature-collection.test.js
@@ -18,11 +18,13 @@ describe('EditableFeatureCollection', () => {
       properties: {},
       geometry: { type: 'Point', coordinates: [1, 2] }
     };
+
     lineStringFeature = {
       type: 'Feature',
       properties: {},
       geometry: { type: 'LineString', coordinates: [[1, 2], [3, 4]] }
     };
+
     polygonFeature = {
       type: 'Feature',
       properties: {},
@@ -36,16 +38,19 @@ describe('EditableFeatureCollection', () => {
         ]
       }
     };
+
     multiPointFeature = {
       type: 'Feature',
       properties: {},
       geometry: { type: 'MultiPoint', coordinates: [[1, 2], [3, 4]] }
     };
+
     multiLineStringFeature = {
       type: 'Feature',
       properties: {},
       geometry: { type: 'MultiLineString', coordinates: [[[1, 2], [3, 4]], [[5, 6], [7, 8]]] }
     };
+
     multiPolygonFeature = {
       type: 'Feature',
       properties: {},
@@ -65,6 +70,7 @@ describe('EditableFeatureCollection', () => {
         ]
       }
     };
+
     featureCollection = {
       type: 'FeatureCollection',
       features: [
@@ -92,12 +98,13 @@ describe('EditableFeatureCollection', () => {
         type: 'FeatureCollection',
         features: [pointFeature]
       });
-      features.replacePosition(0, [], [10, 20]);
+      const updatedFeatures = features.replacePosition(0, [], [10, 20]);
 
+      expect(updatedFeatures).not.toBe(features);
       expect(pointFeature.geometry.coordinates).toEqual([1, 2]);
     });
 
-    it('replaces coordinate in Point', () => {
+    it('replaces position in Point', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [pointFeature]
@@ -110,7 +117,7 @@ describe('EditableFeatureCollection', () => {
       expect(actualCoordinates).toEqual(expectedCoordinates);
     });
 
-    it('replaces first coordinate in LineString', () => {
+    it('replaces first position in LineString', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [lineStringFeature]
@@ -123,7 +130,7 @@ describe('EditableFeatureCollection', () => {
       expect(actualCoordinates).toEqual(expectedCoordinates);
     });
 
-    it('replaces middle coordinate in Polygon', () => {
+    it('replaces middle position in Polygon', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [polygonFeature]
@@ -141,7 +148,7 @@ describe('EditableFeatureCollection', () => {
       expect(actualCoordinates).toEqual(expectedCoordinates);
     });
 
-    it('replaces last coordinate when replacing first coordinate in Polygon', () => {
+    it('replaces last position when replacing first position in Polygon', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [polygonFeature]
@@ -157,7 +164,7 @@ describe('EditableFeatureCollection', () => {
       expect(actualCoordinates).toEqual(expectedCoordinates);
     });
 
-    it('replaces first coordinate when replacing last coordinate in Polygon', () => {
+    it('replaces first position when replacing last position in Polygon', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [polygonFeature]
@@ -180,8 +187,9 @@ describe('EditableFeatureCollection', () => {
         type: 'FeatureCollection',
         features: [lineStringFeature]
       });
-      features.removePosition(0, [0]);
+      const updatedFeatures = features.removePosition(0, [0]);
 
+      expect(updatedFeatures).not.toBe(features);
       expect(lineStringFeature.geometry.coordinates).toEqual([[1, 2], [3, 4]]);
     });
 
@@ -196,7 +204,7 @@ describe('EditableFeatureCollection', () => {
       );
     });
 
-    it('removes first coordinate in LineString', () => {
+    it('removes first position in LineString', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [lineStringFeature]
@@ -209,7 +217,7 @@ describe('EditableFeatureCollection', () => {
       expect(actualCoordinates).toEqual(expectedCoordinates);
     });
 
-    it('removes middle coordinate in Polygon', () => {
+    it('removes middle position in Polygon', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [polygonFeature]
@@ -225,7 +233,7 @@ describe('EditableFeatureCollection', () => {
       expect(actualCoordinates).toEqual(expectedCoordinates);
     });
 
-    it('changes last coordinate when removing first coordinate in Polygon', () => {
+    it('changes last position when removing first position in Polygon', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [polygonFeature]
@@ -241,7 +249,7 @@ describe('EditableFeatureCollection', () => {
       expect(actualCoordinates).toEqual(expectedCoordinates);
     });
 
-    it('changes first coordinate when removing last coordinate in Polygon', () => {
+    it('changes first position when removing last position in Polygon', () => {
       const features = new EditableFeatureCollection({
         type: 'FeatureCollection',
         features: [polygonFeature]
@@ -255,6 +263,109 @@ describe('EditableFeatureCollection', () => {
       ];
 
       expect(actualCoordinates).toEqual(expectedCoordinates);
+    });
+  });
+
+  describe('addPosition()', () => {
+    it(`doesn't mutate original`, () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [lineStringFeature]
+      });
+      const updatedFeatures = features.addPosition(0, [1], [2, 3]);
+
+      expect(updatedFeatures).not.toBe(features);
+      expect(lineStringFeature.geometry.coordinates).toEqual([[1, 2], [3, 4]]);
+    });
+
+    it('throws exception when attempting to add position to Point', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [pointFeature]
+      });
+
+      expect(() => features.addPosition(0, [], [3, 4])).toThrow(
+        'Unable to add a position to a Point feature'
+      );
+    });
+
+    it('adds position to beginning of LineString', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [lineStringFeature]
+      });
+      const updatedFeatures = features.addPosition(0, [0], [10, 20]);
+
+      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+      const expectedCoordinates = [[10, 20], [1, 2], [3, 4]];
+
+      expect(actualCoordinates).toEqual(expectedCoordinates);
+    });
+
+    it('adds position to middle of LineString', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [lineStringFeature]
+      });
+      const updatedFeatures = features.addPosition(0, [1], [10, 20]);
+
+      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+      const expectedCoordinates = [[1, 2], [10, 20], [3, 4]];
+
+      expect(actualCoordinates).toEqual(expectedCoordinates);
+    });
+
+    it('adds position to end of LineString', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [lineStringFeature]
+      });
+      const updatedFeatures = features.addPosition(0, [2], [10, 20]);
+
+      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+      const expectedCoordinates = [[1, 2], [3, 4], [10, 20]];
+
+      expect(actualCoordinates).toEqual(expectedCoordinates);
+    });
+
+    it('adds position in Polygon', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [polygonFeature]
+      });
+      const updatedFeatures = features
+        .addPosition(0, [0, 1], [0, -1])
+        .addPosition(0, [1, 4], [0, -0.5]);
+
+      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+      const expectedCoordinates = [
+        [[-1, -1], [0, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
+        [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [0, -0.5], [-0.5, -0.5]]
+      ];
+
+      expect(actualCoordinates).toEqual(expectedCoordinates);
+    });
+
+    it('throws exception attempting to add before first position in Polygon', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [polygonFeature]
+      });
+
+      expect(() => features.addPosition(0, [1, 0])).toThrow(
+        'Invalid position index for polygon: 0. Points must be added to a Polygon between the first and last point.'
+      );
+    });
+
+    it('throws exception attempting to add after last position in Polygon', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [polygonFeature]
+      });
+
+      expect(() => features.addPosition(0, [1, 5])).toThrow(
+        'Invalid position index for polygon: 5. Points must be added to a Polygon between the first and last point.'
+      );
     });
   });
 
@@ -280,7 +391,7 @@ describe('EditableFeatureCollection', () => {
       const actual = features.getEditHandles(0);
       const expected = [
         { position: [1, 2], positionIndexes: [0], type: 'existing' },
-        { position: [2, 3], positionIndexes: [0], type: 'intermediate' },
+        { position: [2, 3], positionIndexes: [1], type: 'intermediate' },
         { position: [3, 4], positionIndexes: [1], type: 'existing' }
       ];
 
@@ -296,22 +407,22 @@ describe('EditableFeatureCollection', () => {
       const actual = features.getEditHandles(0);
       const expected = [
         { position: [-1, -1], positionIndexes: [0, 0], type: 'existing' },
-        { position: [0, -1], positionIndexes: [0, 0], type: 'intermediate' },
+        { position: [0, -1], positionIndexes: [0, 1], type: 'intermediate' },
         { position: [1, -1], positionIndexes: [0, 1], type: 'existing' },
-        { position: [1, 0], positionIndexes: [0, 1], type: 'intermediate' },
+        { position: [1, 0], positionIndexes: [0, 2], type: 'intermediate' },
         { position: [1, 1], positionIndexes: [0, 2], type: 'existing' },
-        { position: [0, 1], positionIndexes: [0, 2], type: 'intermediate' },
+        { position: [0, 1], positionIndexes: [0, 3], type: 'intermediate' },
         { position: [-1, 1], positionIndexes: [0, 3], type: 'existing' },
-        { position: [-1, 0], positionIndexes: [0, 3], type: 'intermediate' },
+        { position: [-1, 0], positionIndexes: [0, 4], type: 'intermediate' },
         { position: [-1, -1], positionIndexes: [0, 4], type: 'existing' },
         { position: [-0.5, -0.5], positionIndexes: [1, 0], type: 'existing' },
-        { position: [-0.5, 0], positionIndexes: [1, 0], type: 'intermediate' },
+        { position: [-0.5, 0], positionIndexes: [1, 1], type: 'intermediate' },
         { position: [-0.5, 0.5], positionIndexes: [1, 1], type: 'existing' },
-        { position: [0, 0.5], positionIndexes: [1, 1], type: 'intermediate' },
+        { position: [0, 0.5], positionIndexes: [1, 2], type: 'intermediate' },
         { position: [0.5, 0.5], positionIndexes: [1, 2], type: 'existing' },
-        { position: [0.5, 0], positionIndexes: [1, 2], type: 'intermediate' },
+        { position: [0.5, 0], positionIndexes: [1, 3], type: 'intermediate' },
         { position: [0.5, -0.5], positionIndexes: [1, 3], type: 'existing' },
-        { position: [0, -0.5], positionIndexes: [1, 3], type: 'intermediate' },
+        { position: [0, -0.5], positionIndexes: [1, 4], type: 'intermediate' },
         { position: [-0.5, -0.5], positionIndexes: [1, 4], type: 'existing' }
       ];
 
@@ -342,10 +453,10 @@ describe('EditableFeatureCollection', () => {
       const actual = features.getEditHandles(0);
       const expected = [
         { position: [1, 2], positionIndexes: [0, 0], type: 'existing' },
-        { position: [2, 3], positionIndexes: [0, 0], type: 'intermediate' },
+        { position: [2, 3], positionIndexes: [0, 1], type: 'intermediate' },
         { position: [3, 4], positionIndexes: [0, 1], type: 'existing' },
         { position: [5, 6], positionIndexes: [1, 0], type: 'existing' },
-        { position: [6, 7], positionIndexes: [1, 0], type: 'intermediate' },
+        { position: [6, 7], positionIndexes: [1, 1], type: 'intermediate' },
         { position: [7, 8], positionIndexes: [1, 1], type: 'existing' }
       ];
 
@@ -361,31 +472,31 @@ describe('EditableFeatureCollection', () => {
       const actual = features.getEditHandles(0);
       const expected = [
         { position: [-1, -1], positionIndexes: [0, 0, 0], type: 'existing' },
-        { position: [0, -1], positionIndexes: [0, 0, 0], type: 'intermediate' },
+        { position: [0, -1], positionIndexes: [0, 0, 1], type: 'intermediate' },
         { position: [1, -1], positionIndexes: [0, 0, 1], type: 'existing' },
-        { position: [1, 0], positionIndexes: [0, 0, 1], type: 'intermediate' },
+        { position: [1, 0], positionIndexes: [0, 0, 2], type: 'intermediate' },
         { position: [1, 1], positionIndexes: [0, 0, 2], type: 'existing' },
-        { position: [0, 1], positionIndexes: [0, 0, 2], type: 'intermediate' },
+        { position: [0, 1], positionIndexes: [0, 0, 3], type: 'intermediate' },
         { position: [-1, 1], positionIndexes: [0, 0, 3], type: 'existing' },
-        { position: [-1, 0], positionIndexes: [0, 0, 3], type: 'intermediate' },
+        { position: [-1, 0], positionIndexes: [0, 0, 4], type: 'intermediate' },
         { position: [-1, -1], positionIndexes: [0, 0, 4], type: 'existing' },
         { position: [-0.5, -0.5], positionIndexes: [0, 1, 0], type: 'existing' },
-        { position: [-0.5, 0], positionIndexes: [0, 1, 0], type: 'intermediate' },
+        { position: [-0.5, 0], positionIndexes: [0, 1, 1], type: 'intermediate' },
         { position: [-0.5, 0.5], positionIndexes: [0, 1, 1], type: 'existing' },
-        { position: [0, 0.5], positionIndexes: [0, 1, 1], type: 'intermediate' },
+        { position: [0, 0.5], positionIndexes: [0, 1, 2], type: 'intermediate' },
         { position: [0.5, 0.5], positionIndexes: [0, 1, 2], type: 'existing' },
-        { position: [0.5, 0], positionIndexes: [0, 1, 2], type: 'intermediate' },
+        { position: [0.5, 0], positionIndexes: [0, 1, 3], type: 'intermediate' },
         { position: [0.5, -0.5], positionIndexes: [0, 1, 3], type: 'existing' },
-        { position: [0, -0.5], positionIndexes: [0, 1, 3], type: 'intermediate' },
+        { position: [0, -0.5], positionIndexes: [0, 1, 4], type: 'intermediate' },
         { position: [-0.5, -0.5], positionIndexes: [0, 1, 4], type: 'existing' },
         { position: [2, -1], positionIndexes: [1, 0, 0], type: 'existing' },
-        { position: [3, -1], positionIndexes: [1, 0, 0], type: 'intermediate' },
+        { position: [3, -1], positionIndexes: [1, 0, 1], type: 'intermediate' },
         { position: [4, -1], positionIndexes: [1, 0, 1], type: 'existing' },
-        { position: [4, 0], positionIndexes: [1, 0, 1], type: 'intermediate' },
+        { position: [4, 0], positionIndexes: [1, 0, 2], type: 'intermediate' },
         { position: [4, 1], positionIndexes: [1, 0, 2], type: 'existing' },
-        { position: [3, 1], positionIndexes: [1, 0, 2], type: 'intermediate' },
+        { position: [3, 1], positionIndexes: [1, 0, 3], type: 'intermediate' },
         { position: [2, 1], positionIndexes: [1, 0, 3], type: 'existing' },
-        { position: [2, 0], positionIndexes: [1, 0, 3], type: 'intermediate' },
+        { position: [2, 0], positionIndexes: [1, 0, 4], type: 'intermediate' },
         { position: [2, -1], positionIndexes: [1, 0, 4], type: 'existing' }
       ];
 

--- a/src/test/lib/editable-feature-collection.test.js
+++ b/src/test/lib/editable-feature-collection.test.js
@@ -266,7 +266,7 @@ describe('EditableFeatureCollection', () => {
       });
 
       const actual = features.getEditHandles(0);
-      const expected = [{ position: [1, 2], positionIndexes: [], handleType: 'existing' }];
+      const expected = [{ position: [1, 2], positionIndexes: [], type: 'existing' }];
 
       expect(actual).toEqual(expected);
     });
@@ -279,95 +279,117 @@ describe('EditableFeatureCollection', () => {
 
       const actual = features.getEditHandles(0);
       const expected = [
-        { position: [1, 2], positionIndexes: [0], handleType: 'existing' },
-        { position: [2, 3], positionIndexes: [0], handleType: 'intermediate' },
-        { position: [3, 4], positionIndexes: [1], handleType: 'existing' }
+        { position: [1, 2], positionIndexes: [0], type: 'existing' },
+        { position: [2, 3], positionIndexes: [0], type: 'intermediate' },
+        { position: [3, 4], positionIndexes: [1], type: 'existing' }
       ];
 
       expect(actual).toEqual(expected);
     });
 
-    // it('gets edit handles for Polygon', () => {
-    //   const features = new EditableFeatureCollection({
-    //     type: 'FeatureCollection',
-    //     features: [polygonFeature]
-    //   });
+    it('gets edit handles for Polygon', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [polygonFeature]
+      });
 
-    //   const actual = features.getEditHandles(0);
-    //   const expected = [
-    //     { position: [-1, -1], positionIndexes: [0, 0], handleType: 'existing' },
-    //     { position: [1, -1], positionIndexes: [0, 1], handleType: 'existing' },
-    //     { position: [1, 1], positionIndexes: [0, 2], handleType: 'existing' },
-    //     { position: [-1, 1], positionIndexes: [0, 3], handleType: 'existing' },
-    //     { position: [-1, -1], positionIndexes: [0, 4], handleType: 'existing' },
-    //     { position: [-0.5, -0.5], positionIndexes: [1, 0], handleType: 'existing' },
-    //     { position: [-0.5, 0.5], positionIndexes: [1, 1], handleType: 'existing' },
-    //     { position: [0.5, 0.5], positionIndexes: [1, 2], handleType: 'existing' },
-    //     { position: [0.5, -0.5], positionIndexes: [1, 3], handleType: 'existing' },
-    //     { position: [-0.5, -0.5], positionIndexes: [1, 4], handleType: 'existing' }
-    //   ];
+      const actual = features.getEditHandles(0);
+      const expected = [
+        { position: [-1, -1], positionIndexes: [0, 0], type: 'existing' },
+        { position: [0, -1], positionIndexes: [0, 0], type: 'intermediate' },
+        { position: [1, -1], positionIndexes: [0, 1], type: 'existing' },
+        { position: [1, 0], positionIndexes: [0, 1], type: 'intermediate' },
+        { position: [1, 1], positionIndexes: [0, 2], type: 'existing' },
+        { position: [0, 1], positionIndexes: [0, 2], type: 'intermediate' },
+        { position: [-1, 1], positionIndexes: [0, 3], type: 'existing' },
+        { position: [-1, 0], positionIndexes: [0, 3], type: 'intermediate' },
+        { position: [-1, -1], positionIndexes: [0, 4], type: 'existing' },
+        { position: [-0.5, -0.5], positionIndexes: [1, 0], type: 'existing' },
+        { position: [-0.5, 0], positionIndexes: [1, 0], type: 'intermediate' },
+        { position: [-0.5, 0.5], positionIndexes: [1, 1], type: 'existing' },
+        { position: [0, 0.5], positionIndexes: [1, 1], type: 'intermediate' },
+        { position: [0.5, 0.5], positionIndexes: [1, 2], type: 'existing' },
+        { position: [0.5, 0], positionIndexes: [1, 2], type: 'intermediate' },
+        { position: [0.5, -0.5], positionIndexes: [1, 3], type: 'existing' },
+        { position: [0, -0.5], positionIndexes: [1, 3], type: 'intermediate' },
+        { position: [-0.5, -0.5], positionIndexes: [1, 4], type: 'existing' }
+      ];
 
-    //   expect(actual).toEqual(expected);
-    // });
+      expect(actual).toEqual(expected);
+    });
 
-    // it('gets edit handles for MultiPoint', () => {
-    //   const features = new EditableFeatureCollection({
-    //     type: 'FeatureCollection',
-    //     features: [multiPointFeature]
-    //   });
+    it('gets edit handles for MultiPoint', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [multiPointFeature]
+      });
 
-    //   const actual = features.getEditHandles(0);
-    //   const expected = [
-    //     { position: [1, 2], positionIndexes: [0], handleType: 'existing' },
-    //     { position: [3, 4], positionIndexes: [1], handleType: 'existing' }
-    //   ];
+      const actual = features.getEditHandles(0);
+      const expected = [
+        { position: [1, 2], positionIndexes: [0], type: 'existing' },
+        { position: [3, 4], positionIndexes: [1], type: 'existing' }
+      ];
 
-    //   expect(actual).toEqual(expected);
-    // });
+      expect(actual).toEqual(expected);
+    });
 
-    // it('gets edit handles for MultiLineString', () => {
-    //   const features = new EditableFeatureCollection({
-    //     type: 'FeatureCollection',
-    //     features: [multiLineStringFeature]
-    //   });
+    it('gets edit handles for MultiLineString', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [multiLineStringFeature]
+      });
 
-    //   const actual = features.getEditHandles(0);
-    //   const expected = [
-    //     { position: [1, 2], positionIndexes: [0, 0], handleType: 'existing' },
-    //     { position: [3, 4], positionIndexes: [0, 1], handleType: 'existing' },
-    //     { position: [5, 6], positionIndexes: [1, 0], handleType: 'existing' },
-    //     { position: [7, 8], positionIndexes: [1, 1], handleType: 'existing' }
-    //   ];
+      const actual = features.getEditHandles(0);
+      const expected = [
+        { position: [1, 2], positionIndexes: [0, 0], type: 'existing' },
+        { position: [2, 3], positionIndexes: [0, 0], type: 'intermediate' },
+        { position: [3, 4], positionIndexes: [0, 1], type: 'existing' },
+        { position: [5, 6], positionIndexes: [1, 0], type: 'existing' },
+        { position: [6, 7], positionIndexes: [1, 0], type: 'intermediate' },
+        { position: [7, 8], positionIndexes: [1, 1], type: 'existing' }
+      ];
 
-    //   expect(actual).toEqual(expected);
-    // });
+      expect(actual).toEqual(expected);
+    });
 
-    // it('gets edit handles for MultiPolygon', () => {
-    //   const features = new EditableFeatureCollection({
-    //     type: 'FeatureCollection',
-    //     features: [multiPolygonFeature]
-    //   });
+    it('gets edit handles for MultiPolygon', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [multiPolygonFeature]
+      });
 
-    //   const actual = features.getEditHandles(0);
-    //   const expected = [
-    //     { position: [-1, -1], positionIndexes: [0, 0, 0], handleType: 'existing' },
-    //     { position: [1, -1], positionIndexes: [0, 0, 1], handleType: 'existing' },
-    //     { position: [1, 1], positionIndexes: [0, 0, 2], handleType: 'existing' },
-    //     { position: [-1, 1], positionIndexes: [0, 0, 3], handleType: 'existing' },
-    //     { position: [-1, -1], positionIndexes: [0, 0, 4], handleType: 'existing' },
-    //     { position: [-0.5, -0.5], positionIndexes: [0, 1, 0], handleType: 'existing' },
-    //     { position: [-0.5, 0.5], positionIndexes: [0, 1, 1], handleType: 'existing' },
-    //     { position: [0.5, 0.5], positionIndexes: [0, 1, 2], handleType: 'existing' },
-    //     { position: [0.5, -0.5], positionIndexes: [0, 1, 3], handleType: 'existing' },
-    //     { position: [-0.5, -0.5], positionIndexes: [0, 1, 4], handleType: 'existing' },
-    //     { position: [2, -1], positionIndexes: [1, 0, 0], handleType: 'existing' },
-    //     { position: [4, -1], positionIndexes: [1, 0, 1], handleType: 'existing' },
-    //     { position: [4, 1], positionIndexes: [1, 0, 2], handleType: 'existing' },
-    //     { position: [2, 1], positionIndexes: [1, 0, 3], handleType: 'existing' },
-    //     { position: [2, -1], positionIndexes: [1, 0, 4], handleType: 'existing' }
-    //   ];
+      const actual = features.getEditHandles(0);
+      const expected = [
+        { position: [-1, -1], positionIndexes: [0, 0, 0], type: 'existing' },
+        { position: [0, -1], positionIndexes: [0, 0, 0], type: 'intermediate' },
+        { position: [1, -1], positionIndexes: [0, 0, 1], type: 'existing' },
+        { position: [1, 0], positionIndexes: [0, 0, 1], type: 'intermediate' },
+        { position: [1, 1], positionIndexes: [0, 0, 2], type: 'existing' },
+        { position: [0, 1], positionIndexes: [0, 0, 2], type: 'intermediate' },
+        { position: [-1, 1], positionIndexes: [0, 0, 3], type: 'existing' },
+        { position: [-1, 0], positionIndexes: [0, 0, 3], type: 'intermediate' },
+        { position: [-1, -1], positionIndexes: [0, 0, 4], type: 'existing' },
+        { position: [-0.5, -0.5], positionIndexes: [0, 1, 0], type: 'existing' },
+        { position: [-0.5, 0], positionIndexes: [0, 1, 0], type: 'intermediate' },
+        { position: [-0.5, 0.5], positionIndexes: [0, 1, 1], type: 'existing' },
+        { position: [0, 0.5], positionIndexes: [0, 1, 1], type: 'intermediate' },
+        { position: [0.5, 0.5], positionIndexes: [0, 1, 2], type: 'existing' },
+        { position: [0.5, 0], positionIndexes: [0, 1, 2], type: 'intermediate' },
+        { position: [0.5, -0.5], positionIndexes: [0, 1, 3], type: 'existing' },
+        { position: [0, -0.5], positionIndexes: [0, 1, 3], type: 'intermediate' },
+        { position: [-0.5, -0.5], positionIndexes: [0, 1, 4], type: 'existing' },
+        { position: [2, -1], positionIndexes: [1, 0, 0], type: 'existing' },
+        { position: [3, -1], positionIndexes: [1, 0, 0], type: 'intermediate' },
+        { position: [4, -1], positionIndexes: [1, 0, 1], type: 'existing' },
+        { position: [4, 0], positionIndexes: [1, 0, 1], type: 'intermediate' },
+        { position: [4, 1], positionIndexes: [1, 0, 2], type: 'existing' },
+        { position: [3, 1], positionIndexes: [1, 0, 2], type: 'intermediate' },
+        { position: [2, 1], positionIndexes: [1, 0, 3], type: 'existing' },
+        { position: [2, 0], positionIndexes: [1, 0, 3], type: 'intermediate' },
+        { position: [2, -1], positionIndexes: [1, 0, 4], type: 'existing' }
+      ];
 
-    //   expect(actual).toEqual(expected);
-    // });
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/src/test/lib/editable-feature-collection.test.js
+++ b/src/test/lib/editable-feature-collection.test.js
@@ -280,93 +280,94 @@ describe('EditableFeatureCollection', () => {
       const actual = features.getEditHandles(0);
       const expected = [
         { position: [1, 2], positionIndexes: [0], handleType: 'existing' },
+        { position: [2, 3], positionIndexes: [0], handleType: 'intermediate' },
         { position: [3, 4], positionIndexes: [1], handleType: 'existing' }
       ];
 
       expect(actual).toEqual(expected);
     });
 
-    it('gets edit handles for Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
+    // it('gets edit handles for Polygon', () => {
+    //   const features = new EditableFeatureCollection({
+    //     type: 'FeatureCollection',
+    //     features: [polygonFeature]
+    //   });
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { position: [-1, -1], positionIndexes: [0, 0], handleType: 'existing' },
-        { position: [1, -1], positionIndexes: [0, 1], handleType: 'existing' },
-        { position: [1, 1], positionIndexes: [0, 2], handleType: 'existing' },
-        { position: [-1, 1], positionIndexes: [0, 3], handleType: 'existing' },
-        { position: [-1, -1], positionIndexes: [0, 4], handleType: 'existing' },
-        { position: [-0.5, -0.5], positionIndexes: [1, 0], handleType: 'existing' },
-        { position: [-0.5, 0.5], positionIndexes: [1, 1], handleType: 'existing' },
-        { position: [0.5, 0.5], positionIndexes: [1, 2], handleType: 'existing' },
-        { position: [0.5, -0.5], positionIndexes: [1, 3], handleType: 'existing' },
-        { position: [-0.5, -0.5], positionIndexes: [1, 4], handleType: 'existing' }
-      ];
+    //   const actual = features.getEditHandles(0);
+    //   const expected = [
+    //     { position: [-1, -1], positionIndexes: [0, 0], handleType: 'existing' },
+    //     { position: [1, -1], positionIndexes: [0, 1], handleType: 'existing' },
+    //     { position: [1, 1], positionIndexes: [0, 2], handleType: 'existing' },
+    //     { position: [-1, 1], positionIndexes: [0, 3], handleType: 'existing' },
+    //     { position: [-1, -1], positionIndexes: [0, 4], handleType: 'existing' },
+    //     { position: [-0.5, -0.5], positionIndexes: [1, 0], handleType: 'existing' },
+    //     { position: [-0.5, 0.5], positionIndexes: [1, 1], handleType: 'existing' },
+    //     { position: [0.5, 0.5], positionIndexes: [1, 2], handleType: 'existing' },
+    //     { position: [0.5, -0.5], positionIndexes: [1, 3], handleType: 'existing' },
+    //     { position: [-0.5, -0.5], positionIndexes: [1, 4], handleType: 'existing' }
+    //   ];
 
-      expect(actual).toEqual(expected);
-    });
+    //   expect(actual).toEqual(expected);
+    // });
 
-    it('gets edit handles for MultiPoint', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPointFeature]
-      });
+    // it('gets edit handles for MultiPoint', () => {
+    //   const features = new EditableFeatureCollection({
+    //     type: 'FeatureCollection',
+    //     features: [multiPointFeature]
+    //   });
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { position: [1, 2], positionIndexes: [0], handleType: 'existing' },
-        { position: [3, 4], positionIndexes: [1], handleType: 'existing' }
-      ];
+    //   const actual = features.getEditHandles(0);
+    //   const expected = [
+    //     { position: [1, 2], positionIndexes: [0], handleType: 'existing' },
+    //     { position: [3, 4], positionIndexes: [1], handleType: 'existing' }
+    //   ];
 
-      expect(actual).toEqual(expected);
-    });
+    //   expect(actual).toEqual(expected);
+    // });
 
-    it('gets edit handles for MultiLineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiLineStringFeature]
-      });
+    // it('gets edit handles for MultiLineString', () => {
+    //   const features = new EditableFeatureCollection({
+    //     type: 'FeatureCollection',
+    //     features: [multiLineStringFeature]
+    //   });
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { position: [1, 2], positionIndexes: [0, 0], handleType: 'existing' },
-        { position: [3, 4], positionIndexes: [0, 1], handleType: 'existing' },
-        { position: [5, 6], positionIndexes: [1, 0], handleType: 'existing' },
-        { position: [7, 8], positionIndexes: [1, 1], handleType: 'existing' }
-      ];
+    //   const actual = features.getEditHandles(0);
+    //   const expected = [
+    //     { position: [1, 2], positionIndexes: [0, 0], handleType: 'existing' },
+    //     { position: [3, 4], positionIndexes: [0, 1], handleType: 'existing' },
+    //     { position: [5, 6], positionIndexes: [1, 0], handleType: 'existing' },
+    //     { position: [7, 8], positionIndexes: [1, 1], handleType: 'existing' }
+    //   ];
 
-      expect(actual).toEqual(expected);
-    });
+    //   expect(actual).toEqual(expected);
+    // });
 
-    it('gets edit handles for MultiPolygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPolygonFeature]
-      });
+    // it('gets edit handles for MultiPolygon', () => {
+    //   const features = new EditableFeatureCollection({
+    //     type: 'FeatureCollection',
+    //     features: [multiPolygonFeature]
+    //   });
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { position: [-1, -1], positionIndexes: [0, 0, 0], handleType: 'existing' },
-        { position: [1, -1], positionIndexes: [0, 0, 1], handleType: 'existing' },
-        { position: [1, 1], positionIndexes: [0, 0, 2], handleType: 'existing' },
-        { position: [-1, 1], positionIndexes: [0, 0, 3], handleType: 'existing' },
-        { position: [-1, -1], positionIndexes: [0, 0, 4], handleType: 'existing' },
-        { position: [-0.5, -0.5], positionIndexes: [0, 1, 0], handleType: 'existing' },
-        { position: [-0.5, 0.5], positionIndexes: [0, 1, 1], handleType: 'existing' },
-        { position: [0.5, 0.5], positionIndexes: [0, 1, 2], handleType: 'existing' },
-        { position: [0.5, -0.5], positionIndexes: [0, 1, 3], handleType: 'existing' },
-        { position: [-0.5, -0.5], positionIndexes: [0, 1, 4], handleType: 'existing' },
-        { position: [2, -1], positionIndexes: [1, 0, 0], handleType: 'existing' },
-        { position: [4, -1], positionIndexes: [1, 0, 1], handleType: 'existing' },
-        { position: [4, 1], positionIndexes: [1, 0, 2], handleType: 'existing' },
-        { position: [2, 1], positionIndexes: [1, 0, 3], handleType: 'existing' },
-        { position: [2, -1], positionIndexes: [1, 0, 4], handleType: 'existing' }
-      ];
+    //   const actual = features.getEditHandles(0);
+    //   const expected = [
+    //     { position: [-1, -1], positionIndexes: [0, 0, 0], handleType: 'existing' },
+    //     { position: [1, -1], positionIndexes: [0, 0, 1], handleType: 'existing' },
+    //     { position: [1, 1], positionIndexes: [0, 0, 2], handleType: 'existing' },
+    //     { position: [-1, 1], positionIndexes: [0, 0, 3], handleType: 'existing' },
+    //     { position: [-1, -1], positionIndexes: [0, 0, 4], handleType: 'existing' },
+    //     { position: [-0.5, -0.5], positionIndexes: [0, 1, 0], handleType: 'existing' },
+    //     { position: [-0.5, 0.5], positionIndexes: [0, 1, 1], handleType: 'existing' },
+    //     { position: [0.5, 0.5], positionIndexes: [0, 1, 2], handleType: 'existing' },
+    //     { position: [0.5, -0.5], positionIndexes: [0, 1, 3], handleType: 'existing' },
+    //     { position: [-0.5, -0.5], positionIndexes: [0, 1, 4], handleType: 'existing' },
+    //     { position: [2, -1], positionIndexes: [1, 0, 0], handleType: 'existing' },
+    //     { position: [4, -1], positionIndexes: [1, 0, 1], handleType: 'existing' },
+    //     { position: [4, 1], positionIndexes: [1, 0, 2], handleType: 'existing' },
+    //     { position: [2, 1], positionIndexes: [1, 0, 3], handleType: 'existing' },
+    //     { position: [2, -1], positionIndexes: [1, 0, 4], handleType: 'existing' }
+    //   ];
 
-      expect(actual).toEqual(expected);
-    });
+    //   expect(actual).toEqual(expected);
+    // });
   });
 });


### PR DESCRIPTION
`EditableGeoJsonLayer` now supports the ability to add new points along a line (`editType=addintermediateposition`). Works with the following geometry types:

* LineString
* Polygon
* MultiLineString
* MultiPolygon

Breaking changes:

* `editingPoint...` props renamed to `editHandlePoint...`
* `getEditingPoint...` props renamed to `getEditHandlePoint...`