### PR TITLE
Draw LineStrings

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -1,0 +1,232 @@
+# EditableGeoJsonLayer
+
+The Editable GeoJSON layer accepts a [GeoJSON](http://geojson.org) `FeatureCollection` and renders the features as editable polygons, lines, and points.
+
+```js
+import DeckGL from 'deck.gl';
+import { EditableGeoJsonLayer } from 'nebula.gl';
+
+const myFeatureCollection = {
+  type: 'FeatureCollection',
+  features: [/* insert features here */]
+};
+
+class App extends React.Component {
+  state = {
+    mode: 'modify',
+    selectedFeatureIndex: 0,
+    data: myFeatureCollection
+  };
+
+  render() {
+    const layer = new EditableGeoJsonLayer({
+      id: 'geojson-layer',
+      data: this.state.data,
+      mode: this.state.mode,
+      selectedFeatureIndex: this.state.selectedFeatureIndex,
+
+      onEdit: ({ updatedData, updatedMode }) => {
+        this.setState({ data: updatedData, mode: updatedMode });
+      }
+    });
+
+    return (<DeckGL {...this.props.viewport} layers={[layer]} />);
+  }
+}
+```
+
+## Properties
+
+Inherits all [deck.gl's Base Layer](https://uber.github.io/deck.gl/#/documentation/deckgl-api-reference/layers/layer) properties.
+
+#### `data` (Object, optional)
+
+* Default: `null`
+
+A [GeoJSON](http://geojson.org) `FeatureCollection` object. The following types of geometry are supported:
+
+* `Point`
+* `LineString`
+* `Polygon`
+* `MultiPoint`
+* `MultiLineString`
+* `MultiPolygon`
+* `GeometryCollection` is not supported.
+
+*Note: passing a single `Feature` is not supported. However, you can pass a `FeatureCollection` containing a single `Feature` and pass `selectedFeatureIndex: 0` to achieve the same result.*
+
+#### `mode` (String, optional)
+
+* Default: `modify`
+
+The `mode` property dictates what type of edits the user can perform and how to handle user interaction events (e.g. pointer events) in order to accomplish those edits.
+
+* `view`: no edits are possible, but selection is still possible
+* `modify`: user can move existing points, add intermediate points along lines, and remove points
+* `extendLineString`: user can add additional points to the end of a `LineString` feature
+
+#### `onEdit` (Function, optional)
+
+The `onEdit` event is the core event provided by this layer and must be handled in order to accept and render edits. The `event` argument includes the following properties:
+
+* `updatedData` (Object): A new `FeatureCollection` with the edit applied.
+  * To accept the edit as is, supply this object into the `data` prop on the next render cycle (e.g. by calling React's `setState` function)
+  * To reject the edit, do nothing
+  * You may also supply a modified version of this object into the `data` prop on the next render cycle (e.g. if you have your own snapping logic).
+* `updatedMode` (String): A suggested `mode` to use after the edit is applied. Often this is the same value. But occasionally, an edit will need to transition the layer from one mode to another.
+* `editType` (String): The type of edit requested. One of:
+  * `movePosition`: A position was moved.
+  * `addPosition`: A position was added (either at the beginning, middle, or end of a feature's coordinates).
+  * `removePosition`: A position was removed.
+* `featureIndex` (Number): The index of edited feature.
+* `positionIndexes` (Array): An array of numbers representing the indexes of the edited position within the features' `coordinates` array
+* `position` (Array): An array containing the ground coordinates (i.e. [lng, lat]) of the edited position (or `null` if it doesn't apply to the type of edit performed)
+
+##### Example
+
+Consider the user removed the third position from a `Polygon`'s first ring, and that `Polygon` was the fourth feature in the `FeatureCollection`. The `event` argument would look like:
+
+```js
+{
+  updatedData: {...},
+  updatedMode: 'modify',
+  editType: 'removePosition',
+  featureIndex: 3,
+  positionIndexes: [1, 2],
+  position: null
+}
+```
+
+#### `pickable` (Boolean, optional)
+
+* Default: `true`
+
+Defaulted to `true` for interactivity.
+
+### GeoJsonLayer Options
+
+The following properties from [GeoJsonLayer](https://uber.github.io/deck.gl/#/documentation/deckgl-api-reference/layers/geojson-layer) are supported and function the same:
+
+* `filled`
+* `stroked`
+* `lineWidthScale`
+* `lineWidthMinPixels`
+* `lineWidthMaxPixels`
+* `lineJointRounded`
+* `lineMiterLimit`
+* `pointRadiusScale`
+* `pointRadiusMinPixels`
+* `pointRadiusMaxPixels`
+* `fp64`
+* `getRadius`
+* `getLineWidth`
+* TODO: `lineDashJustified`
+* TODO: `getLineDashArray`
+
+### Edit Handles Options
+
+Edit handles are the points rendered on a feature to indicate interactive capabilities (e.g. vertices that can be moved). Edit handle objects have the following properties:
+
+* `type` (String): either `existing` for existing positions or `intermediate` for positions half way between two other positions.
+
+#### `editHandlePointRadiusScale` (Number, optional)
+
+* Default: `1`
+
+#### `editHandlePointRadiusMinPixels` (Number, optional)
+
+* Default: `4`
+
+#### `editHandlePointRadiusMaxPixels` (Number, optional)
+
+* Default: `Number.MAX_SAFE_INTEGER`
+
+#### `getEditHandlePointColor` (Function|Array, optional)
+
+* Default: `handle => handle.type === 'existing' ? [0xc0, 0x0, 0x0, 0xff] : [0x0, 0x0, 0x0, 0x80]`
+
+#### `getEditHandlePointRadius` (, optional)
+
+* Default: `handle => (handle.type === 'existing' ? 5 : 3)`
+
+### Data Accessors
+
+#### `getLineColor` (Function|Array, optional)
+
+* Default: `(feature, isSelected) =>
+    isSelected ? [0x90, 0x90, 0x90, 0xff] : [0x0, 0x0, 0x0, 0xff]`
+
+The rgba color of line string and/or the outline of polygon for a GeoJson feature, depending on its type.
+Format is `r, g, b, [a]`. Each component is in the 0-255 range.
+
+* If an array is provided, it is used as the line color for all features.
+* If a function is provided, it is called on each feature to retrieve its line color.
+  * The `isSelected` argument indicates if the given feature is the selected feature
+
+#### `getFillColor` (Function|Array, optional)
+
+* Default: `(feature, isSelected) =>
+    isSelected ? [0x90, 0x90, 0x90, 0x90] : [0x0, 0x0, 0x0, 0x90]`
+
+The solid color of the polygon and point features of a GeoJson.
+Format is `r, g, b, [a]`. Each component is in the 0-255 range.
+
+* If an array is provided, it is used as the fill color for all features.
+* If a function is provided, it is called on each feature to retrieve its fill color.
+  * The `isSelected` argument indicates if the given feature is the selected feature
+
+Note: This accessor is only called for `Polygon`, `MultiPolygon`, `Point`, and `MultiPoint` features.
+
+## Methods
+
+These methods can be overridden in a derived class in order to customize event handling.
+
+### `onClick`
+
+The pointer went down and up without dragging. This method is called regardless if something was picked.
+
+#### `event` argument
+
+* `picks` (Array): An array containing [deck.gl Picking Info Objects](https://uber.github.io/deck.gl/#/documentation/developer-guide/adding-interactivity?section=what-can-be-picked-) for all objects that were under the pointer when clicked, or an empty array if nothing from this layer was under the pointer.
+* `screenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas.
+* `groundCoords` (Array): `[lng, lat]` ground coordinates.
+
+### `onStartDragging`
+
+The pointer went down on something rendered by this layer and the pointer started to move.
+
+* `picks` (Array): An array containing [deck.gl Picking Info Objects](https://uber.github.io/deck.gl/#/documentation/developer-guide/adding-interactivity?section=what-can-be-picked-) for all objects that were under the pointer when it went down.
+* `screenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer was when it was considered to start dragging (should be very close to `dragStartScreenCoords`).
+* `groundCoords` (Array): `[lng, lat]` ground coordinates where the pointer was when it was considered to start dragging (should be very close to `dragStartGroundCoords`).
+* `dragStartScreenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer went down.
+* `dragStartGroundCoords` (Array): `[lng, lat]` ground coordinates where the pointer went down.
+
+*Note: this method is not called if nothing was picked when the pointer went down*
+
+### `onDragging`
+
+The pointer went down on something rendered by this layer and the pointer is moving.
+
+* `picks` (Array): An array containing [deck.gl Picking Info Objects](https://uber.github.io/deck.gl/#/documentation/developer-guide/adding-interactivity?section=what-can-be-picked-) for all objects that were under the pointer when it went down.
+* `screenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer is now.
+* `groundCoords` (Array): `[lng, lat]` ground coordinates where the pointer is now.
+* `dragStartScreenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer went down.
+* `dragStartGroundCoords` (Array): `[lng, lat]` ground coordinates where the pointer went down.
+
+### `onStopDragging`
+
+The pointer went down on something rendered by this layer, the pointer moved, and now the pointer is up.
+
+* `picks` (Array): An array containing [deck.gl Picking Info Objects](https://uber.github.io/deck.gl/#/documentation/developer-guide/adding-interactivity?section=what-can-be-picked-) for all objects that were under the pointer when it went down.
+* `screenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer went up.
+* `groundCoords` (Array): `[lng, lat]` ground coordinates where the pointer went up.
+* `dragStartScreenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer went down.
+* `dragStartGroundCoords` (Array): `[lng, lat]` ground coordinates where the pointer went down.
+
+### `onPointerMove`
+
+The pointer moved, regardless of whether the pointer is down, up, and whether or not something was picked
+
+* `screenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer is now.
+* `groundCoords` (Array): `[lng, lat]` ground coordinates where the pointer is now.
+* `isDragging` (Boolean): `true` if the pointer is moving but it is considered a drag, in this case you likely want to handle `onDragging`

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -25,8 +25,16 @@ class App extends React.Component {
       mode: this.state.mode,
       selectedFeatureIndex: this.state.selectedFeatureIndex,
 
-      onEdit: ({ updatedData, updatedMode }) => {
-        this.setState({ data: updatedData, mode: updatedMode });
+      onEdit: ({
+        updatedData,
+        updatedMode,
+        updatedSelectedFeatureIndex
+      }) => {
+        this.setState({
+          data: updatedData,
+          mode: updatedMode,
+          selectedFeatureIndex: updatedSelectedFeatureIndex
+        });
       }
     });
 
@@ -61,25 +69,42 @@ A [GeoJSON](http://geojson.org) `FeatureCollection` object. The following types 
 
 The `mode` property dictates what type of edits the user can perform and how to handle user interaction events (e.g. pointer events) in order to accomplish those edits.
 
-* `view`: no edits are possible, but selection is still possible
-* `modify`: user can move existing points, add intermediate points along lines, and remove points
-* `extendLineString`: user can add additional points to the end of a `LineString` feature
+* `view`: no edits are possible, but selection is still possible.
+
+* `modify`: user can move existing points, add intermediate points along lines, and remove points.
+
+* `drawLineString`: user can draw a new `LineString` feature (by passing `selectedFeatureIndex: null`) or add additional points to the end of a `LineString` feature.
 
 #### `onEdit` (Function, optional)
 
 The `onEdit` event is the core event provided by this layer and must be handled in order to accept and render edits. The `event` argument includes the following properties:
 
 * `updatedData` (Object): A new `FeatureCollection` with the edit applied.
+
   * To accept the edit as is, supply this object into the `data` prop on the next render cycle (e.g. by calling React's `setState` function)
+
   * To reject the edit, do nothing
+
   * You may also supply a modified version of this object into the `data` prop on the next render cycle (e.g. if you have your own snapping logic).
-* `updatedMode` (String): A suggested `mode` to use after the edit is applied. Often this is the same value. But occasionally, an edit will need to transition the layer from one mode to another.
+
+* `updatedMode` (String): A suggested value to use for `mode` after the edit is applied. Often this is the same value. But occasionally, an edit will need to transition the layer from one mode to another.
+
+* `updatedSelectedFeatureIndex` (Number): A suggested value to use for `selectedFeatureIndex` after the edit is applied. Often this is the same value. But occasionally, an edit will change the selected feature (e.g. when creating a new feature, it goes from `null` to the index of the newly created feature).
+
 * `editType` (String): The type of edit requested. One of:
+
   * `movePosition`: A position was moved.
+
   * `addPosition`: A position was added (either at the beginning, middle, or end of a feature's coordinates).
+
   * `removePosition`: A position was removed.
+
+  * `addLineString`: A new `LineString` feature was added.
+
 * `featureIndex` (Number): The index of edited feature.
+
 * `positionIndexes` (Array): An array of numbers representing the indexes of the edited position within the features' `coordinates` array
+
 * `position` (Array): An array containing the ground coordinates (i.e. [lng, lat]) of the edited position (or `null` if it doesn't apply to the type of edit performed)
 
 ##### Example

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,27 +1,32 @@
 # Overview
-Nebula.gl is a react component. In order to use it you need to put it inside ```MapGL``` and provide
-```viewport``` and ```layers```. ```layers``` is an array, there are multiple types of layers.
 
-# Regular Layers
+[nebula.gl](https://neb.gl) provides editable and interactive map overlay layers, built using the power of [deck.gl](https://uber.github.io/deck.gl).
+
+## EditableGeoJsonLayer
+
+[EditableGeoJsonLayer](./api-reference/layers/editable-geojson-layer.md) is implemented as a deck.gl layer. It provides the ability to view and edit multiple types of geometry formatted as [GeoJSON](https://tools.ietf.org/html/rfc7946) (an open standard format for geometry).
+
 ## Nebula Layers
-These are the **native** type of layers for Nebula.gl. There are multiple examples here.
+
+nebula.gl includes a react component. In order to use it you need to put it inside `MapGL` and provide
+`viewport` and `layers`. `layers` is an array, there are multiple types of layers.
+
+These are the **native** type of layers for nebula.gl. There are multiple examples here.
 They may just display objects or display and allow you to edit objects.
 These layers are rendered using ```WebGL```.
 
 ### Callbacks
+
 When there is the ability to edit, callbacks are provided to inform you of edits.
 More details in [Using Editable Layers](documentation/developer-guide/using-editable-layers)
 
-### GeoJSON
-- GeoJSON is an open standard for geo data.
-Most layers use it to represent their data.
+### Deck.gl Layers
 
-## Deck.gl Layers
-You can use Deck.gl layers inside Nebula.gl. These layers would work the same way as in Deck.gl.
+You can use Deck.gl layers inside nebula.gl. These layers would work the same way as in Deck.gl.
 This way you can combine both types of layers for maximum flexibility.
-These layers are rendered using ```WebGL```.
+These layers are rendered using `WebGL`.
 
-# Overlay Layers
+### Overlay Layers
 These layers are based on HTML and rendered by the browser. You can use them
 for complicated objects that follow map points. They are less performant
 but more flexible. For more details see [Using Html Overlays](documentation/developer-guide/using-html-overlays)

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -63,9 +63,9 @@ export default class Example extends Component<
     this.state = {
       viewport: initialViewport,
       testFeatures: sampleGeoJson,
-      mode: 'edit',
+      mode: 'extendLineString',
       pointsRemovable: true,
-      selectedFeatureIndex: 5
+      selectedFeatureIndex: 3
     };
   }
 

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -202,12 +202,6 @@ export default class Example extends Component<
         }
         this.setState({ testFeatures: updatedData, mode: updatedMode });
       },
-      onStartDraggingPosition: ({ featureIndex, positionIndexes }) => {
-        console.log(`Start dragging position`, featureIndex, positionIndexes); // eslint-disable-line
-      },
-      onStopDraggingPosition: ({ featureIndex, positionIndexes }) => {
-        console.log(`Stop dragging position`, featureIndex, positionIndexes); // eslint-disable-line
-      },
 
       // Specify the same GeoJsonLayer props
       lineWidthMinPixels: 2,

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -63,7 +63,7 @@ export default class Example extends Component<
     this.state = {
       viewport: initialViewport,
       testFeatures: sampleGeoJson,
-      editable: true,
+      mode: 'edit',
       pointsRemovable: true,
       selectedFeatureIndex: 5
     };
@@ -109,7 +109,7 @@ export default class Example extends Component<
   _onLayerClick = info => {
     console.log('onLayerClick', info); // eslint-disable-line
 
-    if (this.state.editable) {
+    if (this.state.mode !== 'view') {
       // don't change selection while editing
       return;
     }
@@ -134,13 +134,16 @@ export default class Example extends Component<
     return (
       <div style={styles.toolbox}>
         <dl style={styles.toolboxList}>
-          <dt style={styles.toolboxTerm}>Allow edit</dt>
+          <dt style={styles.toolboxTerm}>Mode</dt>
           <dd style={styles.toolboxDescription}>
-            <input
-              type="checkbox"
-              checked={this.state.editable}
-              onChange={() => this.setState({ editable: !this.state.editable })}
-            />
+            <select
+              value={this.state.mode}
+              onChange={event => this.setState({ mode: event.target.value })}
+            >
+              <option value="view">view</option>
+              <option value="edit">edit</option>
+              <option value="extendLineString">extendLineString</option>
+            </select>
           </dd>
           <dt style={styles.toolboxTerm}>Allow removing points</dt>
           <dd style={styles.toolboxDescription}>
@@ -183,20 +186,21 @@ export default class Example extends Component<
     const editableGeoJsonLayer = new EditableGeoJsonLayer({
       data: testFeatures,
       selectedFeatureIndex,
-      editable: this.state.editable,
+      mode: this.state.mode,
       fp64: true,
       autoHighlight: true,
 
       // Editing callbacks
-      onEdit: ({ data, editType, featureIndex, positionIndexes, position }) => {
-        if (editType !== 'moveposition') {
-          console.log('onEdit', editType, featureIndex, positionIndexes, position); // eslint-disable-line
+      onEdit: ({ updatedData, updatedMode, editType, featureIndex, positionIndexes, position }) => {
+        if (editType !== 'movePosition') {
+          // Don't log moves since they're really chatty
+          console.log('onEdit', editType, updatedMode, featureIndex, positionIndexes, position); // eslint-disable-line
         }
-        if (editType === 'removeposition' && !this.state.pointsRemovable) {
+        if (editType === 'removePosition' && !this.state.pointsRemovable) {
           // reject the edit
           return;
         }
-        this.setState({ testFeatures: data });
+        this.setState({ testFeatures: updatedData, mode: updatedMode });
       },
       onStartDraggingPosition: ({ featureIndex, positionIndexes }) => {
         console.log(`Start dragging position`, featureIndex, positionIndexes); // eslint-disable-line

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -63,7 +63,7 @@ export default class Example extends Component<
     this.state = {
       viewport: initialViewport,
       testFeatures: sampleGeoJson,
-      mode: 'extendLineString',
+      mode: 'modify',
       pointsRemovable: true,
       selectedFeatureIndex: 3
     };
@@ -141,7 +141,7 @@ export default class Example extends Component<
               onChange={event => this.setState({ mode: event.target.value })}
             >
               <option value="view">view</option>
-              <option value="edit">edit</option>
+              <option value="modify">modify</option>
               <option value="extendLineString">extendLineString</option>
             </select>
           </dd>

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -28,7 +28,7 @@ const styles = {
     padding: 10,
     borderRadius: 4,
     border: '1px solid gray',
-    width: 300,
+    width: 350,
     fontFamily: 'Arial, Helvetica, sans-serif'
   },
   toolboxList: {

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -63,9 +63,9 @@ export default class Example extends Component<
     this.state = {
       viewport: initialViewport,
       testFeatures: sampleGeoJson,
-      mode: 'modify',
+      mode: 'drawLineString',
       pointsRemovable: true,
-      selectedFeatureIndex: 3
+      selectedFeatureIndex: null
     };
   }
 
@@ -106,6 +106,10 @@ export default class Example extends Component<
     }
   }
 
+  _deselectFeature() {
+    this.setState({ selectedFeatureIndex: null });
+  }
+
   _onLayerClick = info => {
     console.log('onLayerClick', info); // eslint-disable-line
 
@@ -142,7 +146,7 @@ export default class Example extends Component<
             >
               <option value="view">view</option>
               <option value="modify">modify</option>
-              <option value="extendLineString">extendLineString</option>
+              <option value="drawLineString">drawLineString</option>
             </select>
           </dd>
           <dt style={styles.toolboxTerm}>Allow removing points</dt>
@@ -157,8 +161,21 @@ export default class Example extends Component<
           <dd style={styles.toolboxDescription}>
             {this.state.selectedFeatureIndex}{' '}
             <span style={{ float: 'right' }}>
-              <button onClick={() => this._decrementSelectedFeature()}>-</button>
-              <button onClick={() => this._incrementSelectedFeature()}>+</button>
+              <button
+                onClick={() => this._decrementSelectedFeature()}
+                title="Select previous feature"
+              >
+                -
+              </button>
+              <button
+                onClick={() => this._incrementSelectedFeature()}
+                title="Select previous feature"
+              >
+                +
+              </button>
+              <button onClick={() => this._deselectFeature()} title="Deselect feature">
+                Deselect
+              </button>
             </span>
           </dd>
           <dt style={styles.toolboxTerm}>Selected feature type</dt>
@@ -191,16 +208,37 @@ export default class Example extends Component<
       autoHighlight: true,
 
       // Editing callbacks
-      onEdit: ({ updatedData, updatedMode, editType, featureIndex, positionIndexes, position }) => {
+      onEdit: ({
+        updatedData,
+        updatedMode,
+        updatedSelectedFeatureIndex,
+        editType,
+        featureIndex,
+        positionIndexes,
+        position
+      }) => {
         if (editType !== 'movePosition') {
           // Don't log moves since they're really chatty
-          console.log('onEdit', editType, updatedMode, featureIndex, positionIndexes, position); // eslint-disable-line
+          // eslint-disable-next-line
+          console.log(
+            'onEdit',
+            editType,
+            updatedMode,
+            updatedSelectedFeatureIndex,
+            featureIndex,
+            positionIndexes,
+            position
+          );
         }
         if (editType === 'removePosition' && !this.state.pointsRemovable) {
           // reject the edit
           return;
         }
-        this.setState({ testFeatures: updatedData, mode: updatedMode });
+        this.setState({
+          testFeatures: updatedData,
+          mode: updatedMode,
+          selectedFeatureIndex: updatedSelectedFeatureIndex
+        });
       },
 
       // Specify the same GeoJsonLayer props

--- a/src/lib/editable-feature-collection.js
+++ b/src/lib/editable-feature-collection.js
@@ -158,14 +158,14 @@ export class EditableFeatureCollection {
    * @param featureIndex The index of the feature to get edit handles
    */
   getEditHandles(featureIndex: number) {
-    let positions = [];
+    let handles = [];
 
     const geometry = this.featureCollection.features[featureIndex].geometry;
 
     switch (geometry.type) {
       case 'Point':
         // positions are not nested
-        positions = [
+        handles = [
           {
             position: geometry.coordinates,
             positionIndexes: [],
@@ -177,20 +177,20 @@ export class EditableFeatureCollection {
       case 'LineString':
         // positions are nested 1 level
         const includeIntermediate = geometry.type !== 'MultiPoint';
-        positions = positions.concat(getEditHandles(geometry.coordinates, [], includeIntermediate));
+        handles = handles.concat(getEditHandles(geometry.coordinates, [], includeIntermediate));
         break;
       case 'Polygon':
       case 'MultiLineString':
         // positions are nested 2 levels
         for (let a = 0; a < geometry.coordinates.length; a++) {
-          positions = positions.concat(getEditHandles(geometry.coordinates[a], [a], true));
+          handles = handles.concat(getEditHandles(geometry.coordinates[a], [a], true));
         }
         break;
       case 'MultiPolygon':
         // positions are nested 3 levels
         for (let a = 0; a < geometry.coordinates.length; a++) {
           for (let b = 0; b < geometry.coordinates[a].length; b++) {
-            positions = positions.concat(getEditHandles(geometry.coordinates[a][b], [a, b], true));
+            handles = handles.concat(getEditHandles(geometry.coordinates[a][b], [a, b], true));
           }
         }
         break;
@@ -198,7 +198,7 @@ export class EditableFeatureCollection {
         throw Error(`Unhandled geometry type: ${geometry.type}`);
     }
 
-    return positions;
+    return handles;
   }
 }
 

--- a/src/lib/editable-feature-collection.js
+++ b/src/lib/editable-feature-collection.js
@@ -1,11 +1,13 @@
 // @flow
 
+// TODO: type FeatureCollection object
+
 export class EditableFeatureCollection {
-  constructor(featureCollection) {
+  constructor(featureCollection: Object) {
     this.featureCollection = featureCollection;
   }
 
-  getObject() {
+  getObject(): Object {
     return this.featureCollection;
   }
 
@@ -136,6 +138,50 @@ export class EditableFeatureCollection {
       geometry: {
         ...featureToUpdate.geometry,
         coordinates: updatedCoordinates
+      }
+    };
+
+    // Immutably replace the feature being edited in the featureCollection
+    const updatedFeatureCollection = {
+      ...this.featureCollection,
+      features: [
+        ...this.featureCollection.features.slice(0, featureIndex),
+        updatedFeature,
+        ...this.featureCollection.features.slice(featureIndex + 1)
+      ]
+    };
+
+    return new EditableFeatureCollection(updatedFeatureCollection);
+  }
+
+  addFeature(feature: Object) {
+    const updatedFeatureCollection = {
+      ...this.featureCollection,
+      features: [...this.featureCollection.features, feature]
+    };
+    return new EditableFeatureCollection(updatedFeatureCollection);
+  }
+
+  upgradePointToLineString(
+    featureIndex: number,
+    positionToAdd: [number, number] | [number, number, number]
+  ): EditableFeatureCollection {
+    const featureToUpdate = this.featureCollection.features[featureIndex];
+
+    if (featureToUpdate.geometry.type !== 'Point') {
+      throw new Error(
+        `Must be performed on a Point feature but requested on ${
+          featureToUpdate.geometry.type
+        } feature`
+      );
+    }
+
+    const updatedFeature = {
+      ...featureToUpdate,
+      geometry: {
+        ...featureToUpdate.geometry,
+        type: 'LineString',
+        coordinates: [featureToUpdate.geometry.coordinates, positionToAdd]
       }
     };
 

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -371,7 +371,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     this.props.onEdit({
       updatedData,
       updatedMode: this.props.mode,
-      editType: 'addIntermediatePosition',
+      editType: 'addPosition',
       featureIndex,
       positionIndexes,
       position: groundCoords
@@ -411,7 +411,8 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       updatedMode: 'extendLineString',
       editType: 'addPosition',
       featureIndex,
-      positionIndexes
+      positionIndexes,
+      position: groundCoords
     });
   }
 

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -13,8 +13,8 @@ const DEFAULT_EDITING_EXISTING_POINT_COLOR = [0xc0, 0x0, 0x0, 0xff];
 const DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR = [0x0, 0x0, 0x0, 0x80];
 
 const defaultProps = {
-  // 'view' | 'edit' | 'addLineString' | 'extendLineString' | 'addPolygon'
-  mode: 'edit',
+  // 'view' | 'modify' | 'addLineString' | 'extendLineString' | 'addPolygon'
+  mode: 'modify',
 
   // Edit and interaction events
   onEdit: () => {},
@@ -276,7 +276,11 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       return;
     }
 
-    if (this.props.mode === 'edit' && editHandleInfo && editHandleInfo.object.type === 'existing') {
+    if (
+      this.props.mode === 'modify' &&
+      editHandleInfo &&
+      editHandleInfo.object.type === 'existing'
+    ) {
       this.handleRemovePosition(selectedFeatureIndex, editHandleInfo.object.positionIndexes);
     } else if (this.props.mode === 'extendLineString') {
       this.handleExtendLineString(selectedFeature, selectedFeatureIndex, groundCoords);
@@ -366,7 +370,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
 
     this.props.onEdit({
       updatedData,
-      updatedMode: 'edit',
+      updatedMode: this.props.mode,
       editType: 'addIntermediatePosition',
       featureIndex,
       positionIndexes,
@@ -387,7 +391,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     if (updatedData) {
       this.props.onEdit({
         updatedData,
-        updatedMode: 'edit',
+        updatedMode: this.props.mode,
         editType: 'removePosition',
         featureIndex,
         positionIndexes

--- a/src/lib/layers/editable-layer.js
+++ b/src/lib/layers/editable-layer.js
@@ -4,14 +4,21 @@
 import { CompositeLayer } from 'deck.gl';
 
 // Minimum number of pixels the pointer must move from the original pointer down to be considered dragging
-// const MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS = 7;
+const MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS = 7;
 
 export default class EditableLayer extends CompositeLayer {
+  // Overridable interaction event handlers
   onClick({ picks, screenCoords, groundCoords }) {
     // default implementation - do nothing
   }
 
-  onStartDragging({ picks, screenCoords, groundCoords }) {
+  onStartDragging({
+    picks,
+    screenCoords,
+    groundCoords,
+    dragStartScreenCoords,
+    dragStartGroundCoords
+  }) {
     // default implementation - do nothing
   }
 
@@ -29,10 +36,14 @@ export default class EditableLayer extends CompositeLayer {
     // default implementation - do nothing
   }
 
+  onPointerMove({ screenCoords, groundCoords, isDragging }) {
+    // default implementation - do nothing
+  }
+
   // TODO: implement onCancelDragging (e.g. drag off screen)
 
   initializeState() {
-    this.state = {
+    this.setState({
       _editableLayerState: {
         // Pointer event handlers
         pointerHandlers: null,
@@ -43,22 +54,22 @@ export default class EditableLayer extends CompositeLayer {
         // Ground coordinates where the pointer went down
         pointerDownGroundCoords: null,
         // Is the pointer dragging (pointer down + moved at least MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS)
-        dragging: false
+        isDragging: false
       }
-    };
+    });
   }
 
   finalizeState() {
-    this.removePointerHandlers();
+    this._removePointerHandlers();
   }
 
   updateState({ props, changeFlags }) {
     // unsubscribe previous layer instance's handlers
-    this.removePointerHandlers();
-    this.addPointerHandlers();
+    this._removePointerHandlers();
+    this._addPointerHandlers();
   }
 
-  removePointerHandlers() {
+  _removePointerHandlers() {
     if (this.state._editableLayerState.pointerHandlers) {
       this.context.gl.canvas.removeEventListener(
         'pointermove',
@@ -76,11 +87,11 @@ export default class EditableLayer extends CompositeLayer {
     this.state._editableLayerState.pointerHandlers = null;
   }
 
-  addPointerHandlers() {
+  _addPointerHandlers() {
     this.state._editableLayerState.pointerHandlers = {
-      onPointerMove: this.onPointerMove.bind(this),
-      onPointerDown: this.onPointerDown.bind(this),
-      onPointerUp: this.onPointerUp.bind(this)
+      onPointerMove: this._onPointerMove.bind(this),
+      onPointerDown: this._onPointerDown.bind(this),
+      onPointerUp: this._onPointerUp.bind(this)
     };
 
     this.context.gl.canvas.addEventListener(
@@ -97,17 +108,7 @@ export default class EditableLayer extends CompositeLayer {
     );
   }
 
-  //
-  //
-  //
-  //
-  //
-  //
-  //
-  //
-  //
-
-  onPointerDown(event) {
+  _onPointerDown(event) {
     const screenCoords = this.getScreenCoords(event);
     const groundCoords = this.getGroundCoords(screenCoords);
 
@@ -125,98 +126,125 @@ export default class EditableLayer extends CompositeLayer {
         pointerDownScreenCoords: screenCoords,
         pointerDownGroundCoords: groundCoords,
         pointerDownPicks: picks,
-        dragging: false
+        isDragging: false
       }
     });
   }
 
-  onPointerMove(event) {
-    // const screenCoords = this.getScreenCoords(event);
-    // const groundCoords = this.context.viewport.unproject([pointerCoords.x, pointerCoords.y]);
-    // if (this.props.mode === 'extendLineString' && this.state.extensionLineString) {
-    //   this.setState({
-    //     extensionLineString: {
-    //       ...this.state.extensionLineString,
-    //       geometry: {
-    //         ...this.state.extensionLineString.geometry,
-    //         coordinates: [this.state.extensionLineString.geometry.coordinates[0], [...position]]
-    //       }
-    //     }
-    //   });
-    //   // TODO: figure out how to properly update state from a pointer event handler
-    //   this.setLayerNeedsUpdate();
-    //   // if (this.state.extensionsLineStringLayer) {
-    //   //   this.state.extensionsLineStringLayer.setNeedsRedraw();
-    //   // }
-    //   // this.setNeedsRedraw('update from pointer event');
-    //   // this.context.layerManager.setNeedsUpdate('update from pointer event');
-    // }
-    // if (!this.state.pointerDownEditHandle) {
-    //   // TODO: only subscribe to pointermove once the pointer goes down (at which point we can remove this check)
-    //   return;
-    // }
-    // // stop propagation to prevent map panning
-    // event.stopPropagation();
-    // if (!this.state.draggingEditHandle) {
-    //   // pointer is moving, but is it moving enough?
-    //   if (
-    //     Math.abs(this.state.pointerDownCoords.x - pointerCoords.x) >
-    //       MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS ||
-    //     Math.abs(this.state.pointerDownCoords.y - pointerCoords.y) >
-    //       MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS
-    //   ) {
-    //     this.state.draggingEditHandle = this.state.pointerDownEditHandle;
-    //     // Fire the start dragging event
-    //     this.props.onStartDraggingPosition({
-    //       featureIndex: this.props.selectedFeatureIndex,
-    //       positionIndexes: this.state.draggingEditHandle.positionIndexes
-    //     });
-    //   } else {
-    //     // pointer barely moved, so nothing else to do
-    //     return;
-    //   }
-    // }
-    // const { positionIndexes } = this.state.draggingEditHandle;
-    // const { selectedFeatureIndex } = this.props;
-    // const updatedData = this.state.editableFeatureCollection
-    //   .replacePosition(selectedFeatureIndex, positionIndexes, position)
-    //   .getObject();
-    // this.props.onEdit({
-    //   updatedData,
-    //   updatedMode: 'edit',
-    //   editType: 'movePosition',
-    //   featureIndex: selectedFeatureIndex,
-    //   positionIndexes,
-    //   position
-    // });
+  _onPointerMove(event) {
+    const screenCoords = this.getScreenCoords(event);
+    const groundCoords = this.getGroundCoords(screenCoords);
+
+    const {
+      pointerDownPicks,
+      pointerDownScreenCoords,
+      pointerDownGroundCoords
+    } = this.state._editableLayerState;
+
+    let { isDragging } = this.state._editableLayerState;
+
+    if (pointerDownPicks && pointerDownPicks.length > 0) {
+      // Pointer went down on something and is moving
+
+      // Stop propagation to prevent map panning
+      // TODO: find a less hacky way to prevent map panning
+      event.stopPropagation();
+
+      // Did it move enough to consider it a drag
+      if (!isDragging && this.movedEnoughForDrag(pointerDownScreenCoords, screenCoords)) {
+        // OK, this is considered dragging
+
+        // Fire the start dragging event
+        this.onStartDragging({
+          picks: pointerDownPicks,
+          screenCoords,
+          groundCoords,
+          dragStartScreenCoords: pointerDownScreenCoords,
+          dragStartGroundCoords: pointerDownGroundCoords
+        });
+
+        isDragging = true;
+        this.setState({
+          _editableLayerState: {
+            ...this.state._editableLayerState,
+            isDragging
+          }
+        });
+      }
+    }
+
+    this.onPointerMove({ screenCoords, groundCoords, isDragging });
+
+    if (isDragging) {
+      this.onDragging({
+        picks: pointerDownPicks,
+        screenCoords,
+        groundCoords,
+        dragStartScreenCoords: pointerDownScreenCoords,
+        dragStartGroundCoords: pointerDownGroundCoords
+      });
+    }
   }
 
-  onPointerUp(event) {
-    // if (this.state.draggingEditHandle) {
-    //   this.props.onStopDraggingPosition({
-    //     featureIndex: this.props.selectedFeatureIndex,
-    //     positionIndexes: this.state.draggingEditHandle.positionIndexes
-    //   });
-    // } else if (this.state.pointerDownCoords) {
-    //   // They didn't drag, so consider it a click
-    //   this.onClick(event);
-    // }
-    // this.setState({
-    //   draggingEditHandle: null,
-    //   pointerDownEditHandle: null,
-    //   pointerDownCoords: null
-    // });
+  _onPointerUp(event) {
+    const screenCoords = this.getScreenCoords(event);
+    const groundCoords = this.getGroundCoords(screenCoords);
+
+    const {
+      pointerDownPicks,
+      pointerDownScreenCoords,
+      pointerDownGroundCoords,
+      isDragging
+    } = this.state._editableLayerState;
+
+    if (!pointerDownScreenCoords) {
+      // This is a pointer up without a pointer down (e.g. user pointer downed elsewhere), so ignore
+      return;
+    }
+
+    if (isDragging) {
+      this.onStopDragging({
+        picks: pointerDownPicks,
+        screenCoords,
+        groundCoords,
+        dragStartScreenCoords: pointerDownScreenCoords,
+        dragStartGroundCoords: pointerDownGroundCoords
+      });
+    } else if (!this.movedEnoughForDrag(pointerDownScreenCoords, screenCoords)) {
+      this.onClick({
+        picks: pointerDownPicks,
+        screenCoords,
+        groundCoords
+      });
+    }
+
+    this.setState({
+      _editableLayerState: {
+        ...this.state._editableLayerState,
+        pointerDownScreenCoords: null,
+        pointerDownGroundCoords: null,
+        pointerDownPicks: null,
+        isDragging: false
+      }
+    });
   }
 
   getScreenCoords(pointerEvent) {
-    return {
-      x: pointerEvent.clientX - this.context.gl.canvas.getBoundingClientRect().x,
-      y: pointerEvent.clientY - this.context.gl.canvas.getBoundingClientRect().y
-    };
+    return [
+      pointerEvent.clientX - this.context.gl.canvas.getBoundingClientRect().x,
+      pointerEvent.clientY - this.context.gl.canvas.getBoundingClientRect().y
+    ];
   }
 
   getGroundCoords(screenCoords) {
-    return this.context.viewport.unproject([screenCoords.x, screenCoords.y]);
+    return this.context.viewport.unproject([screenCoords[0], screenCoords[1]]);
+  }
+
+  movedEnoughForDrag(screenCoords1, screenCoords2) {
+    return (
+      Math.abs(screenCoords1[0] - screenCoords2[0]) > MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS ||
+      Math.abs(screenCoords1[1] - screenCoords2[1]) > MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS
+    );
   }
 }
 

--- a/src/lib/layers/editable-layer.js
+++ b/src/lib/layers/editable-layer.js
@@ -1,0 +1,223 @@
+// @flow
+/* eslint-env browser */
+
+import { CompositeLayer } from 'deck.gl';
+
+// Minimum number of pixels the pointer must move from the original pointer down to be considered dragging
+// const MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS = 7;
+
+export default class EditableLayer extends CompositeLayer {
+  onClick({ picks, screenCoords, groundCoords }) {
+    // default implementation - do nothing
+  }
+
+  onStartDragging({ picks, screenCoords, groundCoords }) {
+    // default implementation - do nothing
+  }
+
+  onDragging({ picks, screenCoords, groundCoords, dragStartScreenCoords, dragStartGroundCoords }) {
+    // default implementation - do nothing
+  }
+
+  onStopDragging({
+    picks,
+    screenCoords,
+    groundCoords,
+    dragStartScreenCoords,
+    dragStartGroundCoords
+  }) {
+    // default implementation - do nothing
+  }
+
+  // TODO: implement onCancelDragging (e.g. drag off screen)
+
+  initializeState() {
+    this.state = {
+      _editableLayerState: {
+        // Pointer event handlers
+        pointerHandlers: null,
+        // Picked objects at the time the pointer went down
+        pointerDownPicks: null,
+        // Screen coordinates where the pointer went down
+        pointerDownScreenCoords: null,
+        // Ground coordinates where the pointer went down
+        pointerDownGroundCoords: null,
+        // Is the pointer dragging (pointer down + moved at least MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS)
+        dragging: false
+      }
+    };
+  }
+
+  finalizeState() {
+    this.removePointerHandlers();
+  }
+
+  updateState({ props, changeFlags }) {
+    // unsubscribe previous layer instance's handlers
+    this.removePointerHandlers();
+    this.addPointerHandlers();
+  }
+
+  removePointerHandlers() {
+    if (this.state._editableLayerState.pointerHandlers) {
+      this.context.gl.canvas.removeEventListener(
+        'pointermove',
+        this.state._editableLayerState.pointerHandlers.onPointerMove
+      );
+      this.context.gl.canvas.removeEventListener(
+        'pointerdown',
+        this.state._editableLayerState.pointerHandlers.onPointerDown
+      );
+      this.context.gl.canvas.removeEventListener(
+        'pointerup',
+        this.state._editableLayerState.pointerHandlers.onPointerUp
+      );
+    }
+    this.state._editableLayerState.pointerHandlers = null;
+  }
+
+  addPointerHandlers() {
+    this.state._editableLayerState.pointerHandlers = {
+      onPointerMove: this.onPointerMove.bind(this),
+      onPointerDown: this.onPointerDown.bind(this),
+      onPointerUp: this.onPointerUp.bind(this)
+    };
+
+    this.context.gl.canvas.addEventListener(
+      'pointermove',
+      this.state._editableLayerState.pointerHandlers.onPointerMove
+    );
+    this.context.gl.canvas.addEventListener(
+      'pointerdown',
+      this.state._editableLayerState.pointerHandlers.onPointerDown
+    );
+    this.context.gl.canvas.addEventListener(
+      'pointerup',
+      this.state._editableLayerState.pointerHandlers.onPointerUp
+    );
+  }
+
+  //
+  //
+  //
+  //
+  //
+  //
+  //
+  //
+  //
+
+  onPointerDown(event) {
+    const screenCoords = this.getScreenCoords(event);
+    const groundCoords = this.getGroundCoords(screenCoords);
+
+    const picks = this.context.layerManager.pickObject({
+      x: screenCoords[0],
+      y: screenCoords[1],
+      mode: 'query',
+      layers: [this.props.id],
+      radius: 10
+    });
+
+    this.setState({
+      _editableLayerState: {
+        ...this.state._editableLayerState,
+        pointerDownScreenCoords: screenCoords,
+        pointerDownGroundCoords: groundCoords,
+        pointerDownPicks: picks,
+        dragging: false
+      }
+    });
+  }
+
+  onPointerMove(event) {
+    // const screenCoords = this.getScreenCoords(event);
+    // const groundCoords = this.context.viewport.unproject([pointerCoords.x, pointerCoords.y]);
+    // if (this.props.mode === 'extendLineString' && this.state.extensionLineString) {
+    //   this.setState({
+    //     extensionLineString: {
+    //       ...this.state.extensionLineString,
+    //       geometry: {
+    //         ...this.state.extensionLineString.geometry,
+    //         coordinates: [this.state.extensionLineString.geometry.coordinates[0], [...position]]
+    //       }
+    //     }
+    //   });
+    //   // TODO: figure out how to properly update state from a pointer event handler
+    //   this.setLayerNeedsUpdate();
+    //   // if (this.state.extensionsLineStringLayer) {
+    //   //   this.state.extensionsLineStringLayer.setNeedsRedraw();
+    //   // }
+    //   // this.setNeedsRedraw('update from pointer event');
+    //   // this.context.layerManager.setNeedsUpdate('update from pointer event');
+    // }
+    // if (!this.state.pointerDownEditHandle) {
+    //   // TODO: only subscribe to pointermove once the pointer goes down (at which point we can remove this check)
+    //   return;
+    // }
+    // // stop propagation to prevent map panning
+    // event.stopPropagation();
+    // if (!this.state.draggingEditHandle) {
+    //   // pointer is moving, but is it moving enough?
+    //   if (
+    //     Math.abs(this.state.pointerDownCoords.x - pointerCoords.x) >
+    //       MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS ||
+    //     Math.abs(this.state.pointerDownCoords.y - pointerCoords.y) >
+    //       MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS
+    //   ) {
+    //     this.state.draggingEditHandle = this.state.pointerDownEditHandle;
+    //     // Fire the start dragging event
+    //     this.props.onStartDraggingPosition({
+    //       featureIndex: this.props.selectedFeatureIndex,
+    //       positionIndexes: this.state.draggingEditHandle.positionIndexes
+    //     });
+    //   } else {
+    //     // pointer barely moved, so nothing else to do
+    //     return;
+    //   }
+    // }
+    // const { positionIndexes } = this.state.draggingEditHandle;
+    // const { selectedFeatureIndex } = this.props;
+    // const updatedData = this.state.editableFeatureCollection
+    //   .replacePosition(selectedFeatureIndex, positionIndexes, position)
+    //   .getObject();
+    // this.props.onEdit({
+    //   updatedData,
+    //   updatedMode: 'edit',
+    //   editType: 'movePosition',
+    //   featureIndex: selectedFeatureIndex,
+    //   positionIndexes,
+    //   position
+    // });
+  }
+
+  onPointerUp(event) {
+    // if (this.state.draggingEditHandle) {
+    //   this.props.onStopDraggingPosition({
+    //     featureIndex: this.props.selectedFeatureIndex,
+    //     positionIndexes: this.state.draggingEditHandle.positionIndexes
+    //   });
+    // } else if (this.state.pointerDownCoords) {
+    //   // They didn't drag, so consider it a click
+    //   this.onClick(event);
+    // }
+    // this.setState({
+    //   draggingEditHandle: null,
+    //   pointerDownEditHandle: null,
+    //   pointerDownCoords: null
+    // });
+  }
+
+  getScreenCoords(pointerEvent) {
+    return {
+      x: pointerEvent.clientX - this.context.gl.canvas.getBoundingClientRect().x,
+      y: pointerEvent.clientY - this.context.gl.canvas.getBoundingClientRect().y
+    };
+  }
+
+  getGroundCoords(screenCoords) {
+    return this.context.viewport.unproject([screenCoords.x, screenCoords.y]);
+  }
+}
+
+EditableLayer.layerName = 'EditableLayer';

--- a/src/test/lib/editable-feature-collection.test.js
+++ b/src/test/lib/editable-feature-collection.test.js
@@ -369,6 +369,76 @@ describe('EditableFeatureCollection', () => {
     });
   });
 
+  describe('addFeature()', () => {
+    it(`doesn't mutate original`, () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: []
+      });
+      features.addFeature(pointFeature);
+
+      expect(features.getObject().features.length).toEqual(0);
+    });
+
+    it('adds feature to empty array', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: []
+      });
+      const actualFeatures = features.addFeature(pointFeature).getObject();
+
+      const expectedFeatures = {
+        type: 'FeatureCollection',
+        features: [pointFeature]
+      };
+
+      expect(actualFeatures).toEqual(expectedFeatures);
+    });
+
+    it('adds feature to end of array', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [multiPointFeature]
+      });
+      const actualFeatures = features.addFeature(multiLineStringFeature).getObject();
+
+      const expectedFeatures = {
+        type: 'FeatureCollection',
+        features: [multiPointFeature, multiLineStringFeature]
+      };
+
+      expect(actualFeatures).toEqual(expectedFeatures);
+    });
+  });
+
+  describe('upgradePointToLineString()', () => {
+    it('upgrades a Point to a LineString', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [pointFeature]
+      });
+      const updatedFeatures = features.upgradePointToLineString(0, [3, 4]);
+
+      const actualType = updatedFeatures.getObject().features[0].geometry.type;
+      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+      const expectedCoordinates = [[1, 2], [3, 4]];
+
+      expect(actualType).toEqual('LineString');
+      expect(actualCoordinates).toEqual(expectedCoordinates);
+    });
+
+    it('throws exception attempting to call on non-Point', () => {
+      const features = new EditableFeatureCollection({
+        type: 'FeatureCollection',
+        features: [polygonFeature]
+      });
+
+      expect(() => features.upgradePointToLineString(0, [3, 4])).toThrow(
+        'Must be performed on a Point feature but requested on Polygon feature'
+      );
+    });
+  });
+
   describe('getEditHandles()', () => {
     it('gets edit handles for Point', () => {
       const features = new EditableFeatureCollection({


### PR DESCRIPTION
## Summary
Ability to add a new `LineString` feature or extend an existing one. Also introduces `EditableGeoJsonLayer` "modes".

![draw-line-string](https://user-images.githubusercontent.com/469582/42285002-6e6db1a2-7f6b-11e8-8d62-ac0cf2a7f2b3.gif)

## Details
The following modes are now implemented:

* `view`: view only, no editing capabilities
* `edit`: modify existing features (e.g. move points, add intermediate points along lines, remove points)
* `drawLineString`: add new `LineString` feature or add points onto the end of a `LineString` feature

`EditableGeoJsonLayer` can now serve as a base class in order to override or extend certain interactions. The following functions can be overridden:

* `onClick({ picks, screenCoords, groundCoords })`
* `onStartDragging({ picks, screenCoords, groundCoords, dragStartScreenCoords, dragStartGroundCoords })`
* `onDragging({ picks, screenCoords, groundCoords, dragStartScreenCoords, dragStartGroundCoords })`
* `onStopDragging({ picks, screenCoords, groundCoords, dragStartScreenCoords, dragStartGroundCoords })`
* `onPointerMove({ screenCoords, groundCoords, isDragging })`
* `picks` is an array of picking info obtained from `Deck.pickObject` when the pointer went down


## Breaking changes

* Removed `onStartDraggingPosition` prop. This can now be done by extending `EditableGeoJsonLayer`. Also, you can get a more semantic version of this event with `onEdit({editType}) { editType === 'addIntermediatePosition` }` and `onEdit({editType}) { editType === 'movePosition' }`
* Removed `onStopDraggingPosition` prop. This can now be done by extending `EditableGeoJsonLayer`.

Fixes #14.

