### PR TITLE
add editType 'finishMovePosition'

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -115,7 +115,7 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `addFeature`: A new feature was added. Its index is reflected in `featureIndex`
 
-  * `finishMovePosition`: A position finished moving (indicated by `mouseup`).
+  * `finishMovePosition`: A position finished moving (indicated by `pointerup`).
 
 * `featureIndex` (Number): The index of the edited/added feature.
 

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -113,7 +113,9 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `removePosition`: A position was removed.
 
-  * `addFeature`: A new feature was added. Its index is reflected in `featureIndex`.
+  * `addFeature`: A new feature was added. Its index is reflected in `featureIndex`
+
+  * `finishMovePosition`: A position finished moving (indicated by `mouseup`).
 
 * `featureIndex` (Number): The index of the edited/added feature.
 

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -285,6 +285,30 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     }
   }
 
+  onStopDragging({
+    picks,
+    screenCoords,
+    groundCoords,
+    dragStartScreenCoords,
+    dragStartGroundCoords
+  }: Object) {
+    const { selectedFeature } = this.state;
+    const { selectedFeatureIndex } = this.props;
+    const editHandleInfo = this.getPickedEditHandle(picks);
+
+    if (!selectedFeature) {
+      return;
+    }
+
+    if (editHandleInfo) {
+      this.handleFinishMovePosition(
+        selectedFeatureIndex,
+        editHandleInfo.object.positionIndexes,
+        groundCoords
+      );
+    }
+  }
+
   onPointerMove({ screenCoords, groundCoords, isDragging }: Object) {
     if (this.props.mode === 'drawLineString' || this.props.mode === 'drawPolygon') {
       const drawFeature = this.getDrawFeature(
@@ -377,6 +401,22 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       updatedMode: this.props.mode,
       updatedSelectedFeatureIndex: featureIndex,
       editType: 'movePosition',
+      featureIndex,
+      positionIndexes,
+      position: groundCoords
+    });
+  }
+
+  handleFinishMovePosition(featureIndex: number, positionIndexes: number, groundCoords: number[]) {
+    const updatedData = this.state.editableFeatureCollection
+      .replacePosition(featureIndex, positionIndexes, groundCoords)
+      .getObject();
+
+    this.props.onEdit({
+      updatedData,
+      updatedMode: this.props.mode,
+      updatedSelectedFeatureIndex: featureIndex,
+      editType: 'finishMovePosition',
       featureIndex,
       positionIndexes,
       position: groundCoords


### PR DESCRIPTION
Add new `editType = 'finishMovePosition'` to distinguish when a drag has finished and expose it in `onEdit` callback