### PR TITLE
Don't hard-code port for examples

### DIFF
--- a/examples/deck/package.json
+++ b/examples/deck/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start": "webpack-dev-server --progress --hot --port 3000 --open",
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3000 --open"
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
     "mapbox-gl": "0.43",

--- a/examples/pit-lines/package.json
+++ b/examples/pit-lines/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start": "webpack-dev-server --progress --hot --port 3000 --open",
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3000 --open"
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
     "deck.gl": "6.0.0-beta.1",

--- a/examples/sf/package.json
+++ b/examples/sf/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start": "webpack-dev-server --progress --hot --port 3000 --open",
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3000 --open"
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
     "deck.gl": "6.0.0-beta.1",


### PR DESCRIPTION
You can achieve the same as before with `yarn start-local --port 3000`. This way, users can choose whatever port number they want, or stick with the default (8080).