### PR TITLE
Allow panning map when dragging polygon fill

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -254,3 +254,4 @@ The pointer moved, regardless of whether the pointer is down, up, and whether or
 * `screenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer is now.
 * `groundCoords` (Array): `[lng, lat]` ground coordinates where the pointer is now.
 * `isDragging` (Boolean): `true` if the pointer is moving but it is considered a drag, in this case you likely want to handle `onDragging`
+* `pointerDownPicks` (Array): An array containing [deck.gl Picking Info Objects](https://uber.github.io/deck.gl/#/documentation/developer-guide/adding-interactivity?section=what-can-be-picked-) for all objects that were under the pointer when it went down, or `null` if pointer is moving without pointer down.

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -277,12 +277,12 @@ export default class EditableGeoJsonLayer extends EditableLayer {
   }: Object) {
     const { selectedFeature } = this.state;
     const { selectedFeatureIndex } = this.props;
-    const editHandleInfo = this.getPickedEditHandle(picks);
 
     if (!selectedFeature) {
       return;
     }
 
+    const editHandleInfo = this.getPickedEditHandle(picks);
     if (editHandleInfo) {
       this.handleMovePosition(
         selectedFeatureIndex,
@@ -316,7 +316,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     }
   }
 
-  onPointerMove({ screenCoords, groundCoords, isDragging }: Object) {
+  onPointerMove({ screenCoords, groundCoords, isDragging, pointerDownPicks, sourceEvent }: Object) {
     if (this.props.mode === 'drawLineString' || this.props.mode === 'drawPolygon') {
       const drawFeature = this.getDrawFeature(
         this.state.selectedFeature,
@@ -328,6 +328,15 @@ export default class EditableGeoJsonLayer extends EditableLayer {
 
       // TODO: figure out how to properly update state from a pointer event handler
       this.setLayerNeedsUpdate();
+    }
+
+    if (pointerDownPicks && pointerDownPicks.length > 0) {
+      const editHandleInfo = this.getPickedEditHandle(pointerDownPicks);
+      if (editHandleInfo) {
+        // TODO: find a less hacky way to prevent map panning
+        // Stop propagation to prevent map panning while dragging an edit handle
+        sourceEvent.stopPropagation();
+      }
     }
   }
 

--- a/src/lib/layers/editable-layer.js
+++ b/src/lib/layers/editable-layer.js
@@ -42,7 +42,7 @@ export default class EditableLayer extends CompositeLayer {
     // default implementation - do nothing
   }
 
-  onPointerMove({ screenCoords, groundCoords, isDragging }: Object) {
+  onPointerMove({ screenCoords, groundCoords, isDragging, sourceEvent }: Object) {
     // default implementation - do nothing
   }
 
@@ -153,10 +153,6 @@ export default class EditableLayer extends CompositeLayer {
     if (pointerDownPicks && pointerDownPicks.length > 0) {
       // Pointer went down on something and is moving
 
-      // Stop propagation to prevent map panning
-      // TODO: find a less hacky way to prevent map panning
-      event.stopPropagation();
-
       // Did it move enough to consider it a drag
       if (!isDragging && this.movedEnoughForDrag(pointerDownScreenCoords, screenCoords)) {
         // OK, this is considered dragging
@@ -180,7 +176,13 @@ export default class EditableLayer extends CompositeLayer {
       }
     }
 
-    this.onPointerMove({ screenCoords, groundCoords, isDragging });
+    this.onPointerMove({
+      screenCoords,
+      groundCoords,
+      isDragging,
+      pointerDownPicks,
+      sourceEvent: event
+    });
 
     if (isDragging) {
       this.onDragging({


### PR DESCRIPTION
Previous behavior:
Dragging an edit handle suppresses panning map but instead moves the point.
Dragging a line or fill suppresses panning map but does nothing else.

New behavior:
Dragging an edit handle suppresses panning map but instead moves the point.
Dragging a line or fill doesn't suppress panning map. In the future, this may move the feature (perhaps only when also holding down Ctrl or Cmd)