### PR TITLE
Downgradable geometry

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -144,9 +144,9 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `movePosition`: A position was moved.
 
-  * `addPosition`: A position was added (either at the beginning, middle, or end of a feature's coordinates). Note: this may result in a feature being upgraded from one type to another (e.g. `Point` to `LineString` or `LineString` to `Polygon`).
+  * `addPosition`: A position was added (either at the beginning, middle, or end of a feature's coordinates). Note: this may result in a feature being "upgraded" from one type to another (e.g. `Point` to `LineString` or `LineString` to `Polygon`).
 
-  * `removePosition`: A position was removed.
+  * `removePosition`: A position was removed. Note: this may result in a feature being "downgraded" from one type to another (e.g. `Polygon` to `LineString` or `LineString` to `Point`). It also may result in multiple positions being removed in order to maintain valid GeoJSON (e.g. removing a point from a triangular hole will remove the hole entirely).
 
   * `addFeature`: A new feature was added. Its index is reflected in `featureIndex`
 

--- a/examples/sf/example.js
+++ b/examples/sf/example.js
@@ -54,15 +54,10 @@ export default class Example extends Component<
   constructor() {
     super();
 
-    // TODO: once https://github.com/uber/deck.gl/pull/1918 lands, remove this filter since it'll work with MultiPolygons
-    const testPolygonsWithoutMultiPolygons = testPolygons.filter(
-      feature => feature.geometry.type === 'Polygon'
-    );
-
     this.state = {
       viewport: initialViewport,
       allowEdit: true,
-      testFeatures: { type: 'FeatureCollection', features: testPolygonsWithoutMultiPolygons }
+      testFeatures: { type: 'FeatureCollection', features: testPolygons }
     };
 
     this.testSegments = [];

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -277,6 +277,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     if (this.props.mode === 'modify') {
       if (editHandleInfo && editHandleInfo.object.type === 'existing') {
         this.handleRemovePosition(
+          this.props.data.features[editHandleInfo.object.featureIndex],
           editHandleInfo.object.featureIndex,
           editHandleInfo.object.positionIndexes
         );
@@ -560,14 +561,18 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     });
   }
 
-  handleRemovePosition(featureIndex: number, positionIndexes: number) {
+  handleRemovePosition(
+    selectedFeature: GeoJsonFeature,
+    featureIndex: number,
+    positionIndexes: number
+  ) {
     let updatedData;
     try {
       updatedData = this.state.editableFeatureCollection
         .removePosition(featureIndex, positionIndexes)
         .getObject();
     } catch (error) {
-      // Sometimes we can't remove a position (e.g. trying to remove a position from a triangle)
+      // This happens if user attempts to remove the last point
     }
 
     if (updatedData) {

--- a/src/types.js
+++ b/src/types.js
@@ -41,7 +41,7 @@ export type Viewport = {
 
 export type GeoJsonGeometry = {
   type: string,
-  coordinates: Array<mixed>
+  coordinates: Array<any>
 };
 
 export type GeoJsonFeature = {


### PR DESCRIPTION
With this functionality, a user can continue to remove points until they're just left with a single point (either a `Point` or `MultiPoint` feature). I call this "downgradable" geometries.

Of course, a consuming application can always choose to reject the edit if, for instance, a position is attempting to be removed from a triangle `Polygon` (as that would downgrade it to a `LineString`).