### PR TITLE
Add props for draw feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run the example
 1. `git clone git@github.com:uber/nebula.gl.git`
 2. `cd nebula.gl`
 3. `yarn`
-4. `cd examples/sf`
+4. `cd examples/deck`
 5. `yarn`
 6. `yarn start-local`
 7. You can view/edit geometry.

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -212,7 +212,7 @@ The additional arguments (in order) are:
 
 ### Drawing Feature
 
-While drawing, portion of a feature which has not been "committed" yet can hold its own props. For a LineString, this would be the last line segment moving under the mouse. For a Polygon, this would be the last segment and the fill moving under the mouse. For Rectangles and Circles, this would be the whole feature during drawing. Define the properties with the following accessors:
+While creating a new feature in any of the `draw` modes, portion of a feature which has not been "committed" yet can hold its own props. For a LineString, this would be the last line segment moving under the mouse. For a Polygon, this would be the last segment and the fill moving under the mouse. For Rectangles and Circles, this would be the whole feature during drawing. Define the properties with the following accessors:
 
 * `getDrawLineColor`
 * `getDrawFillColor`

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -8,7 +8,9 @@ import { EditableGeoJsonLayer } from 'nebula.gl';
 
 const myFeatureCollection = {
   type: 'FeatureCollection',
-  features: [/* insert features here */]
+  features: [
+    /* insert features here */
+  ]
 };
 
 class App extends React.Component {
@@ -25,11 +27,7 @@ class App extends React.Component {
       mode: this.state.mode,
       selectedFeatureIndexes: this.state.selectedFeatureIndexes,
 
-      onEdit: ({
-        updatedData,
-        updatedMode,
-        updatedSelectedFeatureIndexes
-      }) => {
+      onEdit: ({ updatedData, updatedMode, updatedSelectedFeatureIndexes }) => {
         this.setState({
           data: updatedData,
           mode: updatedMode,
@@ -38,7 +36,7 @@ class App extends React.Component {
       }
     });
 
-    return (<DeckGL {...this.props.viewport} layers={[layer]} />);
+    return <DeckGL {...this.props.viewport} layers={[layer]} />;
   }
 }
 ```
@@ -61,7 +59,7 @@ A [GeoJSON](http://geojson.org) `FeatureCollection` object. The following types 
 * `MultiPolygon`
 * `GeometryCollection` is not supported.
 
-*Note: passing a single `Feature` is not supported. However, you can pass a `FeatureCollection` containing a single `Feature` and pass `selectedFeatureIndexes: [0]` to achieve the same result.*
+_Note: passing a single `Feature` is not supported. However, you can pass a `FeatureCollection` containing a single `Feature` and pass `selectedFeatureIndexes: [0]` to achieve the same result._
 
 #### `mode` (String, optional)
 
@@ -118,6 +116,7 @@ The `mode` property dictates what type of edits the user can perform and how to 
 * Default: `[]`
 
 * The `selectedFeatueIndexes` property distinguishes which features to treat as selected.
+
   * Features are identified by their index in the collection.
 
   * Selection of a feature causes style accessors to render a different style, defined in function such as `getLineColor` and `getFillColor`.
@@ -207,7 +206,22 @@ The following accessors function the same, but can accept additional arguments:
 
 The additional arguments (in order) are:
 
+* `feature`: the given feature
 * `isSelected`: indicates if the given feature is a selected feature
+* `mode`: the current value of the `mode` prop
+
+### Drawing Feature
+
+While drawing, portion of a feature which has not been "committed" yet can hold its own props. For a LineString, this would be the last line segment moving under the mouse. For a Polygon, this would be the last segment and the fill moving under the mouse. For Rectangles and Circles, this would be the whole feature during drawing. Define the properties with the following accessors:
+
+* `getDrawLineColor`
+* `getDrawFillColor`
+* `getDrawLineWidth`
+* `getDrawLineDashArray`
+
+The following accessors default to the same values as the existing feature accessors above. The arguments in order:
+
+* `feature`: the given feature
 * `mode`: the current value of the `mode` prop
 
 ### Edit Handles
@@ -310,7 +324,7 @@ The pointer went down on something rendered by this layer and the pointer starte
 * `dragStartScreenCoords` (Array): `[x, y]` screen pixel coordinates relative to the deck.gl canvas where the pointer went down.
 * `dragStartGroundCoords` (Array): `[lng, lat]` ground coordinates where the pointer went down.
 
-*Note: this method is not called if nothing was picked when the pointer went down*
+_Note: this method is not called if nothing was picked when the pointer went down_
 
 ### `onDragging`
 

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -281,6 +281,7 @@ export default class Example extends Component<
       // Specify the same GeoJsonLayer props
       lineWidthMinPixels: 2,
       pointRadiusMinPixels: 5,
+      getLineDashArray: (f, isSelected, currMode) => [0, 0],
 
       // Accessors receive an isSelected argument
       getFillColor: (feature, isSelected) => {
@@ -293,7 +294,11 @@ export default class Example extends Component<
       // Can customize editing points props
       getEditHandlePointColor: handle =>
         handle.type === 'existing' ? [0xff, 0x80, 0x00, 0xff] : [0x0, 0x0, 0x0, 0x80],
-      editHandlePointRadiusScale: 2
+      editHandlePointRadiusScale: 2,
+
+      // customize drawing line style
+      getDrawLineDashArray: (f, currMode) => [7, 4],
+      getDrawLineColor: (f, currMode) => [0x8f, 0x8f, 0x8f, 0xff]
     });
 
     return (

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -45,6 +45,12 @@ const defaultProps = {
   getLineDashArray: (feature, isSelected, mode) =>
     isSelected && mode !== 'view' ? [7, 4] : [0, 0],
 
+  // drawing line
+  getDrawLineDashArray: (f, mode) => [7, 4],
+  getDrawLineColor: (f, mode) => DEFAULT_SELECTED_LINE_COLOR,
+  getDrawFillColor: (f, mode) => DEFAULT_SELECTED_FILL_COLOR,
+  getDrawLineWidth: (f, mode) => (f && f.properties && f.properties.lineWidth) || 1,
+
   editHandleType: 'point',
 
   // point handles
@@ -241,9 +247,6 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       return [];
     }
 
-    const getLineDashArray = () =>
-      this.props.getLineDashArray(this.state.selectedFeature, true, this.props.mode);
-
     const layer = new GeoJsonLayer(
       this.getSubLayerProps({
         id: 'draw',
@@ -259,10 +262,11 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         pointRadiusScale: this.props.editHandlePointRadiusScale,
         pointRadiusMinPixels: this.props.editHandlePointRadiusMinPixels,
         pointRadiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
-        getLineColor: feature => this.props.getLineColor(feature, true),
-        getFillColor: feature => this.props.getFillColor(feature, true),
-        getLineDashArray,
-        getRadius: this.props.getEditHandlePointRadius
+        getRadius: this.props.getEditHandlePointRadius,
+        getLineColor: this.props.getDrawLineColor(this.state.selectedFeatures[0]),
+        getLineWidth: this.props.getDrawLineWidth(this.state.selectedFeatures[0]),
+        getFillColor: this.props.getDrawFillColor(this.state.selectedFeatures[0]),
+        getLineDashArray: this.props.getDrawLineDashArray(this.state.selectedFeatures[0])
       })
     );
 

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -522,7 +522,9 @@ export default class EditableGeoJsonLayer extends EditableLayer {
               geometry: {
                 type: 'LineString',
                 coordinates: [
-                  selectedFeature.geometry.coordinates[lastIdx],
+                  selectedFeature.geometry.coordinates[
+                    selectedFeature.geometry.coordinates.length - 1
+                  ],
                   currentPosition,
                   selectedFeature.geometry.coordinates[0]
                 ]

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -497,7 +497,6 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       } else if (mode === 'drawPolygon') {
         // Requires two features, a non-stroked polygon for fill and a
         // line string for the drawing feature
-        const lastIdx = selectedFeature.geometry.coordinates.length - 1;
         drawFeature = {
           type: 'FeatureCollection',
           features: [

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -110,10 +110,10 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       }
     });
 
-    let layers = [this.createDrawLayers()];
+    let layers = [new GeoJsonLayer(subLayerProps)];
 
-    layers = layers.concat(new GeoJsonLayer(subLayerProps));
     layers = layers.concat(this.createPointLayers());
+    layers = layers.concat(this.createDrawLayers());
 
     return layers;
   }


### PR DESCRIPTION
Adds the following props to `EditableGeoJsonLayer`:

* `getDrawLineColor`
* `getDrawFillColor`
* `getDrawLineWidth`
* `getDrawLineDashArray`

Looks like this:

![draw-line-style](https://user-images.githubusercontent.com/15949651/43594186-9bb810ce-9647-11e8-937a-bed72af3ed39.gif)
