### PR TITLE
Fix getDrawLine props

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -221,7 +221,8 @@ While creating a new feature in any of the `draw` modes, portion of a feature wh
 
 The following accessors default to the same values as the existing feature accessors above. The arguments in order:
 
-* `feature`: the given feature
+* `feature`: the segment/polygon that represents the "uncommitted" feature
+* `selectedFeature`: the "committed" feature which is being drawn/extended
 * `mode`: the current value of the `mode` prop
 
 ### Edit Handles

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -281,7 +281,7 @@ export default class Example extends Component<
       // Specify the same GeoJsonLayer props
       lineWidthMinPixels: 2,
       pointRadiusMinPixels: 5,
-      getLineDashArray: (f, isSelected, currMode) => [0, 0],
+      getLineDashArray: () => [0, 0],
 
       // Accessors receive an isSelected argument
       getFillColor: (feature, isSelected) => {
@@ -297,8 +297,8 @@ export default class Example extends Component<
       editHandlePointRadiusScale: 2,
 
       // customize drawing line style
-      getDrawLineDashArray: (f, currMode) => [7, 4],
-      getDrawLineColor: (f, currMode) => [0x8f, 0x8f, 0x8f, 0xff]
+      getDrawLineDashArray: () => [7, 4],
+      getDrawLineColor: () => [0x8f, 0x8f, 0x8f, 0xff]
     });
 
     return (

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -460,7 +460,8 @@ export default class EditableGeoJsonLayer extends EditableLayer {
           geometry: {
             type: 'LineString',
             coordinates: [startPosition, endPosition]
-          }
+          },
+          properties: selectedFeature.properties || {}
         };
       } else if (mode === 'drawRectangle') {
         const corner1 = ((selectedFeature.geometry.coordinates: any): Array<number>);
@@ -470,11 +471,15 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         const maxX = Math.max(corner1[0], corner2[0]);
         const maxY = Math.max(corner1[1], corner2[1]);
 
-        drawFeature = bboxPolygon([minX, minY, maxX, maxY]);
+        drawFeature = Object.assign({}, bboxPolygon([minX, minY, maxX, maxY]), {
+          properties: selectedFeature.properties || {}
+        });
       } else if (mode === 'drawCircle') {
         const center = ((selectedFeature.geometry.coordinates: any): Array<number>);
         const radius = Math.max(distance(selectedFeature, groundCoords || center), 0.001);
-        drawFeature = circle(center, radius);
+        drawFeature = Object.assign({}, circle(center, radius), {
+          properties: selectedFeature.properties || {}
+        });
       }
     } else if (selectedFeature.geometry.type === 'LineString') {
       const lastPositionOfLineString =
@@ -489,7 +494,8 @@ export default class EditableGeoJsonLayer extends EditableLayer {
           geometry: {
             type: 'LineString',
             coordinates: [lastPositionOfLineString, currentPosition]
-          }
+          },
+          properties: selectedFeature.properties || {}
         };
       } else if (mode === 'drawPolygon') {
         // Requires two features, a non-stroked polygon for fill and a
@@ -511,7 +517,8 @@ export default class EditableGeoJsonLayer extends EditableLayer {
                     selectedFeature.geometry.coordinates[0]
                   ]
                 ]
-              }
+              },
+              properties: selectedFeature.properties || {}
             },
             {
               type: 'Feature',
@@ -524,15 +531,12 @@ export default class EditableGeoJsonLayer extends EditableLayer {
                   currentPosition,
                   selectedFeature.geometry.coordinates[0]
                 ]
-              }
+              },
+              properties: selectedFeature.properties || {}
             }
           ]
         };
       }
-    }
-    if (selectedFeature && selectedFeature.properties) {
-      // inherit geojson properties from selected feature
-      drawFeature.properties = Object.assign({}, selectedFeature.properties);
     }
     return drawFeature;
   }

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -264,9 +264,12 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         pointRadiusMinPixels: this.props.editHandlePointRadiusMinPixels,
         pointRadiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
         getRadius: this.props.getEditHandlePointRadius,
-        getLineColor: feature => this.props.getDrawLineColor(feature, this.props.mode),
-        getLineWidth: feature => this.props.getDrawLineWidth(feature, this.props.mode),
-        getFillColor: feature => this.props.getDrawFillColor(feature, this.props.mode),
+        getLineColor: feature =>
+          this.props.getDrawLineColor(feature, this.state.selectedFeatures[0], this.props.mode),
+        getLineWidth: feature =>
+          this.props.getDrawLineWidth(feature, this.state.selectedFeatures[0], this.props.mode),
+        getFillColor: feature =>
+          this.props.getDrawFillColor(feature, this.state.selectedFeatures[0], this.props.mode),
         getLineDashArray: feature => this.props.getDrawLineDashArray(feature, this.props.mode)
       })
     );
@@ -460,8 +463,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
           geometry: {
             type: 'LineString',
             coordinates: [startPosition, endPosition]
-          },
-          properties: selectedFeature.properties || {}
+          }
         };
       } else if (mode === 'drawRectangle') {
         const corner1 = ((selectedFeature.geometry.coordinates: any): Array<number>);
@@ -471,15 +473,11 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         const maxX = Math.max(corner1[0], corner2[0]);
         const maxY = Math.max(corner1[1], corner2[1]);
 
-        drawFeature = Object.assign({}, bboxPolygon([minX, minY, maxX, maxY]), {
-          properties: selectedFeature.properties || {}
-        });
+        drawFeature = bboxPolygon([minX, minY, maxX, maxY]);
       } else if (mode === 'drawCircle') {
         const center = ((selectedFeature.geometry.coordinates: any): Array<number>);
         const radius = Math.max(distance(selectedFeature, groundCoords || center), 0.001);
-        drawFeature = Object.assign({}, circle(center, radius), {
-          properties: selectedFeature.properties || {}
-        });
+        drawFeature = circle(center, radius);
       }
     } else if (selectedFeature.geometry.type === 'LineString') {
       const lastPositionOfLineString =
@@ -494,8 +492,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
           geometry: {
             type: 'LineString',
             coordinates: [lastPositionOfLineString, currentPosition]
-          },
-          properties: selectedFeature.properties || {}
+          }
         };
       } else if (mode === 'drawPolygon') {
         // Requires two features, a non-stroked polygon for fill and a
@@ -517,8 +514,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
                     selectedFeature.geometry.coordinates[0]
                   ]
                 ]
-              },
-              properties: selectedFeature.properties || {}
+              }
             },
             {
               type: 'Feature',
@@ -531,8 +527,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
                   currentPosition,
                   selectedFeature.geometry.coordinates[0]
                 ]
-              },
-              properties: selectedFeature.properties || {}
+              }
             }
           ]
         };

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -270,7 +270,8 @@ export default class EditableGeoJsonLayer extends EditableLayer {
           this.props.getDrawLineWidth(feature, this.state.selectedFeatures[0], this.props.mode),
         getFillColor: feature =>
           this.props.getDrawFillColor(feature, this.state.selectedFeatures[0], this.props.mode),
-        getLineDashArray: feature => this.props.getDrawLineDashArray(feature, this.props.mode)
+        getLineDashArray: feature =>
+          this.props.getDrawLineDashArray(feature, this.state.selectedFeatures[0], this.props.mode)
       })
     );
 

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -264,13 +264,10 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         pointRadiusMinPixels: this.props.editHandlePointRadiusMinPixels,
         pointRadiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
         getRadius: this.props.getEditHandlePointRadius,
-        getLineColor: this.props.getDrawLineColor(this.state.selectedFeatures[0], this.props.mode),
-        getLineWidth: this.props.getDrawLineWidth(this.state.selectedFeatures[0], this.props.mode),
-        getFillColor: this.props.getDrawFillColor(this.state.selectedFeatures[0], this.props.mode),
-        getLineDashArray: this.props.getDrawLineDashArray(
-          this.state.selectedFeatures[0],
-          this.props.mode
-        )
+        getLineColor: feature => this.props.getDrawLineColor(feature, this.props.mode),
+        getLineWidth: feature => this.props.getDrawLineWidth(feature, this.props.mode),
+        getFillColor: feature => this.props.getDrawFillColor(feature, this.props.mode),
+        getLineDashArray: feature => this.props.getDrawLineDashArray(feature, this.props.mode)
       })
     );
 
@@ -532,6 +529,10 @@ export default class EditableGeoJsonLayer extends EditableLayer {
           ]
         };
       }
+    }
+    if (selectedFeature && selectedFeature.properties) {
+      // inherit geojson properties from selected feature
+      drawFeature.properties = Object.assign({}, selectedFeature.properties);
     }
     return drawFeature;
   }


### PR DESCRIPTION
`getDrawLine` props had a bad implementation and weren't working. Updated to make them actual function accessors.

Also updated them to have `selectedFeature` context, so that the style of the "draw feature" can be a function of the feature being drawn/extended. Might be irrelevant since #46 looks to change all accessors anyways.