### PR TITLE
Add outline and strokeWidth missing props

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -245,6 +245,14 @@ Edit handle objects can be represented by either points or icons. `editHandlePoi
 
 * Default: `1`
 
+#### `editHandlePointOutline` (Boolean, optional)
+
+* Default: `false`
+
+#### `editHandlePointStrokeWidth` (Number, optional)
+
+* Default: `1`
+
 #### `editHandlePointRadiusMinPixels` (Number, optional)
 
 * Default: `4`

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -55,6 +55,8 @@ const defaultProps = {
 
   // point handles
   editHandlePointRadiusScale: 1,
+  editHandlePointOutline: false,
+  editHandlePointStrokeWidth: 1,
   editHandlePointRadiusMinPixels: 4,
   editHandlePointRadiusMaxPixels: Number.MAX_SAFE_INTEGER,
   getEditHandlePointColor: handle =>
@@ -231,6 +233,8 @@ export default class EditableGeoJsonLayer extends EditableLayer {
 
                 // Proxy editing point props
                 radiusScale: this.props.editHandlePointRadiusScale,
+                outline: this.props.editHandlePointOutline,
+                strokeWidth: this.props.editHandlePointStrokeWidth,
                 radiusMinPixels: this.props.editHandlePointRadiusMinPixels,
                 radiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
                 getRadius: this.props.getEditHandlePointRadius,
@@ -261,6 +265,8 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         lineJointRounded: this.props.lineJointRounded,
         lineMiterLimit: this.props.lineMiterLimit,
         pointRadiusScale: this.props.editHandlePointRadiusScale,
+        outline: this.props.editHandlePointOutline,
+        strokeWidth: this.props.editHandlePointStrokeWidth,
         pointRadiusMinPixels: this.props.editHandlePointRadiusMinPixels,
         pointRadiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
         getRadius: this.props.getEditHandlePointRadius,

--- a/website/src/components/Hero.js
+++ b/website/src/components/Hero.js
@@ -99,6 +99,8 @@ class EditableGeoJsonLayer2 extends EditableGeoJsonLayer {
 
               // Proxy editing point props
               radiusScale: this.props.editHandlePointRadiusScale,
+              outline: this.props.editHandlePointOutline,
+              strokeWidth: this.props.editHandlePointStrokeWidth,
               radiusMinPixels: this.props.editHandlePointRadiusMinPixels,
               radiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
               getRadius: this.props.getEditHandlePointRadius,


### PR DESCRIPTION
Proxy props for Scatterplotlayer's `outline` and `strokeWidth` props.