### PR TITLE
add support for creating an individual point feature

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -71,6 +71,10 @@ The `mode` property dictates what type of edits the user can perform and how to 
 
 * `modify`: user can move existing points, add intermediate points along lines, and remove points.
 
+* `drawPoint`: user can draw a `Point` feature by clicking positions to add.
+
+  * If no feature is selected, clicking will create a new `Point` feature.
+
 * `drawLineString`: user can draw a `LineString` feature by clicking positions to add.
 
   * If no feature is selected, clicking will create a new feature `Point` feature and select it (by passing its index as `updatedSelectedFeatureIndexes`).

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -92,14 +92,8 @@ export default class Example extends Component<
 
   _onLayerClick = info => {
     console.log('onLayerClick', info); // eslint-disable-line
-    const { mode } = this.state;
 
-    if (mode === 'drawPoint') {
-      // TODO why is info.index *always* 0 for a new feature?
-      this.setState({ selectedFeatureIndexes: [] });
-    }
-
-    if (mode !== 'view') {
+    if (this.state.mode !== 'view') {
       // don't change selection while editing
       return;
     }

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -92,8 +92,14 @@ export default class Example extends Component<
 
   _onLayerClick = info => {
     console.log('onLayerClick', info); // eslint-disable-line
+    const { mode } = this.state;
 
-    if (this.state.mode !== 'view') {
+    if (mode === 'drawPoint') {
+      // TODO why is info.index *always* 0 for a new feature?
+      this.setState({ selectedFeatureIndexes: [] });
+    }
+
+    if (mode !== 'view') {
       // don't change selection while editing
       return;
     }
@@ -163,6 +169,7 @@ export default class Example extends Component<
             >
               <option value="view">view</option>
               <option value="modify">modify</option>
+              <option value="drawPoint">drawPoint</option>
               <option value="drawLineString">drawLineString</option>
               <option value="drawPolygon">drawPolygon</option>
               <option value="drawRectangle">drawRectangle</option>

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -301,6 +301,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         );
       }
     } else if (
+      this.props.mode === 'drawPoint' ||
       this.props.mode === 'drawLineString' ||
       this.props.mode === 'drawPolygon' ||
       this.props.mode === 'drawRectangle' ||


### PR DESCRIPTION
Basically, I just added a no-op mode of "drawPoint". It works because the first click when adding a feature creates a "Point" feature anyway. I could have done the same thing using "drawLineString", but it seems nebula will transiently render the dotted line for the "next" point in the line string, which is visible for a 1/2 second or so.