### PR TITLE
Cursor handling

### DIFF
--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -310,6 +310,7 @@ export default class Example extends Component<
         <link href="https://api.mapbox.com/mapbox-gl-js/v0.44.0/mapbox-gl.css" rel="stylesheet" />
         <DeckGL
           {...viewport}
+          getCursor={editableGeoJsonLayer.getCursor.bind(editableGeoJsonLayer)}
           layers={[editableGeoJsonLayer]}
           views={new MapView({ id: 'basemap', controller: MapController })}
           onLayerClick={this._onLayerClick}


### PR DESCRIPTION
Fixes #28 

![cursors](https://user-images.githubusercontent.com/469582/45400768-ba84e580-b60a-11e8-8f6c-fb80bcc1bc44.gif)


## TODO
[ ] Documentation
[ ] Should cursor change to `pointer` when hovering a feature in `view` mode?
[✓] Would `cell` be better than `copy` for the intermediate point cursor? The copy one on Chrome is not that great. [here](https://www.w3schools.com/cssref/tryit.asp?filename=trycss_cursor) are possible cursors.