### PR TITLE
Feature/enable remove position via keypress

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -179,6 +179,8 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `movePosition`: A position was moved.
 
+  * `clickPosition`: A position was clicked.
+
   * `addPosition`: A position was added (either at the beginning, middle, or end of a feature's coordinates). Note: this may result in a feature being "upgraded" from one type to another (e.g. `Point` to `LineString` or `LineString` to `Polygon`).
 
   * `removePosition`: A position was removed. Note: this may result in a feature being "downgraded" from one type to another (e.g. `Polygon` to `LineString` or `LineString` to `Point`). It also may result in multiple positions being removed in order to maintain valid GeoJSON (e.g. removing a point from a triangular hole will remove the hole entirely).
@@ -350,6 +352,24 @@ The height of each edit handle, in pixels.
 * Default: `0`
 
 The rotating angle of each object, in degrees.
+
+#### `editHandleRemoveOnKeyPress` (Boolean, optional)
+
+* Default `false`
+
+Setting this prop to `true` allows an edit handle to be removed when a key is pressed (the default way of removing an edit handle is simply to click it).
+
+#### `editHandleRemoveOnKeyPressTriggerKey` (String, optional)
+
+* Default `'d'`
+
+Specifies the key to trigger the removal of an edit handle.
+
+#### `editHandleTarget` (Object, optional)
+
+* Default `null`
+
+Allows a consuming application to specify an edit handle to be removed when a key is pressed and  `editHandleRemoveOnKeyPress` is `true`. The actual edit handle instance is provided to the application in the `onEdit` callback when the `editType` is `clickPosition`.
 
 ## Methods
 

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -193,6 +193,18 @@ export default class Example extends Component<
               }
             />
           </dd>
+          <dt style={styles.toolboxTerm}>Remove Point On Key Press</dt>
+          <dd style={styles.toolboxDescription}>
+            <input
+              type="checkbox"
+              checked={this.state.editHandleRemoveOnKeyPress}
+              onChange={() =>
+                this.setState({
+                  editHandleRemoveOnKeyPress: !this.state.editHandleRemoveOnKeyPress
+                })
+              }
+            />
+          </dd>
           <dt style={styles.toolboxTerm}>Select Features</dt>
           <dd style={styles.toolboxDescription}>
             <input
@@ -208,7 +220,13 @@ export default class Example extends Component<
   }
 
   render() {
-    const { testFeatures, selectedFeatureIndexes, mode } = this.state;
+    const {
+      testFeatures,
+      selectedFeatureIndexes,
+      mode,
+      editHandleRemoveOnKeyPress,
+      editHandleTarget
+    } = this.state;
 
     const viewport = {
       ...this.state.viewport,
@@ -223,6 +241,8 @@ export default class Example extends Component<
       mode,
       fp64: true,
       autoHighlight: true,
+      editHandleRemoveOnKeyPress,
+      editHandleTarget,
 
       // Editing callbacks
       onEdit: ({
@@ -250,6 +270,14 @@ export default class Example extends Component<
         if (editType === 'removePosition' && !this.state.pointsRemovable) {
           // reject the edit
           return;
+        }
+        if (editType === 'clickPosition') {
+          this.setState({
+            editHandleTarget: {
+              featureIndex,
+              positionIndexes
+            }
+          });
         }
         this.setState({
           testFeatures: updatedData,

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -41,9 +41,6 @@ const defaultProps = {
   pointRadiusMinPixels: 2,
   pointRadiusMaxPixels: Number.MAX_SAFE_INTEGER,
   lineDashJustified: false,
-  removePositionOnKeyPress: false,
-  removePositionTriggerKey: 'd',
-  targetPosition: null,
   getLineColor: (feature, isSelected, mode) =>
     isSelected ? DEFAULT_SELECTED_LINE_COLOR : DEFAULT_LINE_COLOR,
   getFillColor: (feature, isSelected, mode) =>
@@ -85,7 +82,12 @@ const defaultProps = {
     handle.type === 'existing'
       ? DEFAULT_EDITING_EXISTING_POINT_COLOR
       : DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR,
-  getEditHandleIconAngle: 0
+  getEditHandleIconAngle: 0,
+
+  // edit handle removal behavior
+  editHandleRemoveOnKeyPress: false,
+  editHandleRemoveOnKeyPressTriggerKey: 'd',
+  editHandleTarget: null
 };
 
 export default class EditableGeoJsonLayer extends EditableLayer {
@@ -302,31 +304,31 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     const {
       mode,
       data: { features },
-      targetPosition,
-      removePositionOnKeyPress,
-      removePositionTriggerKey
+      editHandleTarget,
+      editHandleRemoveOnKeyPress,
+      editHandleRemoveOnKeyPressTriggerKey
     } = this.props;
     if (
-      removePositionOnKeyPress &&
-      key === removePositionTriggerKey &&
+      editHandleRemoveOnKeyPress &&
+      key === editHandleRemoveOnKeyPressTriggerKey &&
       (mode === 'modify' || mode === 'drawLineString') &&
-      targetPosition
+      editHandleTarget
     ) {
-      const { featureIndex, positionIndexes } = targetPosition;
+      const { featureIndex, positionIndexes } = editHandleTarget;
       this.handleRemovePosition(features[featureIndex], featureIndex, positionIndexes);
     }
   }
 
   onClick({ picks, screenCoords, groundCoords }: Object) {
     const { selectedFeatures } = this.state;
-    const { selectedFeatureIndexes, mode, data, removePositionOnKeyPress } = this.props;
+    const { selectedFeatureIndexes, mode, data, editHandleRemoveOnKeyPress } = this.props;
     const editHandleInfo = this.getPickedEditHandle(picks);
 
     if (mode === 'modify') {
       if (editHandleInfo && editHandleInfo.object.type === 'existing') {
         const { featureIndex, positionIndexes } = editHandleInfo.object;
 
-        if (removePositionOnKeyPress) {
+        if (editHandleRemoveOnKeyPress) {
           // just notify the app which edit handle was clicked, it may then opt in to passing it back to nebula
           this.props.onEdit({
             updatedData: data,

--- a/src/lib/layers/editable-layer.js
+++ b/src/lib/layers/editable-layer.js
@@ -204,7 +204,7 @@ export default class EditableLayer extends CompositeLayer {
     }
   }
 
-  onKeyPress(key) {
+  onKeyPress(key: string) {
     // default implementation - do nothing
   }
 

--- a/src/lib/layers/editable-layer.js
+++ b/src/lib/layers/editable-layer.js
@@ -89,6 +89,10 @@ export default class EditableLayer extends CompositeLayer {
         'pointerup',
         this.state._editableLayerState.pointerHandlers.onPointerUp
       );
+      this.context.gl.canvas.removeEventListener(
+        'keypress',
+        this.state._editableLayerState.pointerHandlers.onKeyPress
+      );
     }
     this.state._editableLayerState.pointerHandlers = null;
   }
@@ -97,7 +101,8 @@ export default class EditableLayer extends CompositeLayer {
     this.state._editableLayerState.pointerHandlers = {
       onPointerMove: this._onPointerMove.bind(this),
       onPointerDown: this._onPointerDown.bind(this),
-      onPointerUp: this._onPointerUp.bind(this)
+      onPointerUp: this._onPointerUp.bind(this),
+      onKeyPress: this._onKeyPress.bind(this)
     };
 
     this.context.gl.canvas.addEventListener(
@@ -111,6 +116,10 @@ export default class EditableLayer extends CompositeLayer {
     this.context.gl.canvas.addEventListener(
       'pointerup',
       this.state._editableLayerState.pointerHandlers.onPointerUp
+    );
+    this.context.gl.canvas.addEventListener(
+      'keypress',
+      this.state._editableLayerState.pointerHandlers.onKeyPress
     );
   }
 
@@ -193,6 +202,14 @@ export default class EditableLayer extends CompositeLayer {
         dragStartGroundCoords: pointerDownGroundCoords
       });
     }
+  }
+
+  onKeyPress(key) {
+    // default implementation - do nothing
+  }
+
+  _onKeyPress({ key }: Object) {
+    this.onKeyPress(key);
   }
 
   _onPointerUp(event: Object) {


### PR DESCRIPTION
(Omitting a GIF since it would appear no differently than the default method of deleting an edit handle)

Basically, this is another usability requirement of the Map Maker application. 