### PR TITLE
Double click on drawPolygon mode, should close the polygon

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -93,6 +93,8 @@ The `mode` property dictates what type of edits the user can perform and how to 
 
   * If a `LineString` feature is selected, clicking will add the clicked position to it. If that clicked position is the first position, the feature will be converted to a `Polygon` feature.
 
+  * If a `LineString` feature is selected, after having 3 points any where double-click the feature will be converted to a `Polygon` feature by closing the shape to first position.
+
   * If multiple features are selected, the user will be prevented from drawing.
 
 * `drawRectangle`: user can draw a new rectanglular `Polygon` feature by clicking two opposing corners of the rectangle.

--- a/src/lib/layers/editable-geojson-layer.js
+++ b/src/lib/layers/editable-geojson-layer.js
@@ -306,7 +306,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       this.props.mode === 'drawPolygon' &&
       selectedFeatures.length === 1 &&
       selectedFeature.geometry.type === 'LineString' &&
-      selectedFeature.geometry.coordinates.length > 5
+      selectedFeature.geometry.coordinates.length > 4
     ) {
       const { coordinates } = selectedFeature.geometry;
       // close the polygon.

--- a/src/lib/layers/editable-layer.js
+++ b/src/lib/layers/editable-layer.js
@@ -11,6 +11,9 @@ export default class EditableLayer extends CompositeLayer {
   onClick({ picks, screenCoords, groundCoords }: Object) {
     // default implementation - do nothing
   }
+  onDoubleClick({ groundCoords }: Object) {
+    // default implementation - do nothing
+  }
 
   onStartDragging({
     picks,
@@ -89,6 +92,10 @@ export default class EditableLayer extends CompositeLayer {
         'pointerup',
         this.state._editableLayerState.pointerHandlers.onPointerUp
       );
+      this.context.gl.canvas.removeEventListener(
+        'dblclick',
+        this.state._editableLayerState.pointerHandlers.onDoubleClick
+      );
     }
     this.state._editableLayerState.pointerHandlers = null;
   }
@@ -97,7 +104,8 @@ export default class EditableLayer extends CompositeLayer {
     this.state._editableLayerState.pointerHandlers = {
       onPointerMove: this._onPointerMove.bind(this),
       onPointerDown: this._onPointerDown.bind(this),
-      onPointerUp: this._onPointerUp.bind(this)
+      onPointerUp: this._onPointerUp.bind(this),
+      onDoubleClick: this._onDoubleClick.bind(this)
     };
 
     this.context.gl.canvas.addEventListener(
@@ -112,6 +120,18 @@ export default class EditableLayer extends CompositeLayer {
       'pointerup',
       this.state._editableLayerState.pointerHandlers.onPointerUp
     );
+    this.context.gl.canvas.addEventListener(
+      'dblclick',
+      this.state._editableLayerState.pointerHandlers.onDoubleClick
+    );
+  }
+
+  _onDoubleClick(event: Object) {
+    const screenCoords = this.getScreenCoords(event);
+    const groundCoords = this.getGroundCoords(screenCoords);
+    this.onDoubleClick({
+      groundCoords
+    });
   }
 
   _onPointerDown(event: Object) {


### PR DESCRIPTION
On the drawPolygon mode, after having 3 points any where double-click the feature will be converted to a Polygon feature by closing the shape to first position.
![polygon-edit-no-timer](https://user-images.githubusercontent.com/1399914/45535354-cf849300-b81b-11e8-8bed-992bf064f99e.gif)
