### PR TITLE
Don't downgrade geometry type

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -203,7 +203,7 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `addPosition`: A position was added (either at the beginning, middle, or end of a feature's coordinates). Note: this may result in a feature being "upgraded" from one type to another (e.g. `Point` to `LineString` or `LineString` to `Polygon`).
 
-  * `removePosition`: A position was removed. Note: this may result in a feature being "downgraded" from one type to another (e.g. `Polygon` to `LineString` or `LineString` to `Point`). It also may result in multiple positions being removed in order to maintain valid GeoJSON (e.g. removing a point from a triangular hole will remove the hole entirely).
+  * `removePosition`: A position was removed. Note: it may result in multiple positions being removed in order to maintain valid GeoJSON (e.g. removing a point from a triangular hole will remove the hole entirely).
 
   * `addFeature`: A new feature was added. Its index is reflected in `featureIndex`
 

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -4,6 +4,7 @@ import window from 'global/window';
 import React, { Component } from 'react';
 import DeckGL, { MapView, MapController } from 'deck.gl';
 import { StaticMap } from 'react-map-gl';
+import circle from '@turf/circle';
 
 import { EditableGeoJsonLayer } from 'nebula.gl';
 
@@ -127,6 +128,23 @@ export default class Example extends Component<
     this.setState({ keyHolded: '' });
   };
 
+  _loadSample = (type: string) => {
+    if (type === 'mixed') {
+      this.setState({
+        testFeatures: sampleGeoJson,
+        selectedFeatureIndexes: []
+      });
+    } else if (type === 'complex') {
+      this.setState({
+        testFeatures: {
+          type: 'FeatureCollection',
+          features: [circle([-122.45, 37.77], 5, { steps: 10000 })]
+        },
+        selectedFeatureIndexes: []
+      });
+    }
+  };
+
   _renderCheckbox(index, featureType) {
     const { selectedFeatureIndexes } = this.state;
     return (
@@ -170,6 +188,11 @@ export default class Example extends Component<
     return (
       <div style={styles.toolbox}>
         <dl style={styles.toolboxList}>
+          <dt style={styles.toolboxTerm}>Load sample data</dt>
+          <dd style={styles.toolboxDescription}>
+            <button onClick={() => this._loadSample('mixed')}>Mixed</button>
+            <button onClick={() => this._loadSample('complex')}>Complex</button>
+          </dd>
           <dt style={styles.toolboxTerm}>Mode</dt>
           <dd style={styles.toolboxDescription}>
             <select

--- a/src/test/lib/editable-feature-collection.test.js
+++ b/src/test/lib/editable-feature-collection.test.js
@@ -4,709 +4,674 @@
 
 import { EditableFeatureCollection } from '../../lib/editable-feature-collection';
 
-describe('EditableFeatureCollection', () => {
-  let pointFeature;
-  let lineStringFeature;
-  let polygonFeature;
-  let multiPointFeature;
-  let multiLineStringFeature;
-  let multiPolygonFeature;
-  let featureCollection;
+let pointFeature;
+let lineStringFeature;
+let polygonFeature;
+let multiPointFeature;
+let multiLineStringFeature;
+let multiPolygonFeature;
+let featureCollection;
 
-  beforeEach(() => {
-    pointFeature = {
-      type: 'Feature',
-      properties: {},
-      geometry: { type: 'Point', coordinates: [1, 2] }
-    };
+beforeEach(() => {
+  pointFeature = {
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'Point', coordinates: [1, 2] }
+  };
 
-    lineStringFeature = {
-      type: 'Feature',
-      properties: {},
-      geometry: { type: 'LineString', coordinates: [[1, 2], [2, 3], [3, 4]] }
-    };
+  lineStringFeature = {
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'LineString', coordinates: [[1, 2], [2, 3], [3, 4]] }
+  };
 
-    polygonFeature = {
-      type: 'Feature',
-      properties: {},
-      geometry: {
-        type: 'Polygon',
-        coordinates: [
-          // exterior ring
+  polygonFeature = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        // exterior ring
+        [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
+        // hole
+        [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
+      ]
+    }
+  };
+
+  multiPointFeature = {
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'MultiPoint', coordinates: [[1, 2], [3, 4]] }
+  };
+
+  multiLineStringFeature = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'MultiLineString',
+      coordinates: [[[1, 2], [2, 3], [3, 4]], [[5, 6], [6, 7], [7, 8]]]
+    }
+  };
+
+  multiPolygonFeature = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'MultiPolygon',
+      coordinates: [
+        [
+          // exterior ring polygon 1
           [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
-          // hole
+          // hole  polygon 1
           [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
+        ],
+        [
+          // exterior ring polygon 2
+          [[2, -1], [4, -1], [4, 1], [2, 1], [2, -1]]
         ]
-      }
-    };
+      ]
+    }
+  };
 
-    multiPointFeature = {
-      type: 'Feature',
-      properties: {},
-      geometry: { type: 'MultiPoint', coordinates: [[1, 2], [3, 4]] }
-    };
+  featureCollection = {
+    type: 'FeatureCollection',
+    features: [
+      pointFeature,
+      lineStringFeature,
+      polygonFeature,
+      multiPointFeature,
+      multiLineStringFeature,
+      multiPolygonFeature
+    ]
+  };
+});
 
-    multiLineStringFeature = {
-      type: 'Feature',
-      properties: {},
-      geometry: {
-        type: 'MultiLineString',
-        coordinates: [[[1, 2], [2, 3], [3, 4]], [[5, 6], [6, 7], [7, 8]]]
-      }
-    };
+describe('getObject()', () => {
+  it('can get real object', () => {
+    const editable = new EditableFeatureCollection(featureCollection);
 
-    multiPolygonFeature = {
-      type: 'Feature',
-      properties: {},
-      geometry: {
-        type: 'MultiPolygon',
-        coordinates: [
-          [
-            // exterior ring polygon 1
-            [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
-            // hole  polygon 1
-            [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
-          ],
-          [
-            // exterior ring polygon 2
-            [[2, -1], [4, -1], [4, 1], [2, 1], [2, -1]]
-          ]
-        ]
-      }
-    };
+    expect(editable.getObject()).toBe(featureCollection);
+  });
+});
 
-    featureCollection = {
+describe('replacePosition()', () => {
+  it(`doesn't mutate original`, () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [pointFeature]
+    });
+    const updatedFeatures = features.replacePosition(0, [], [10, 20]);
+
+    expect(updatedFeatures).not.toBe(features);
+    expect(pointFeature.geometry.coordinates).toEqual([1, 2]);
+  });
+
+  it('replaces position in Point', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [pointFeature]
+    });
+    const updatedFeatures = features.replacePosition(0, [], [10, 20]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [10, 20];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('replaces first position in LineString', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
+    });
+    const updatedFeatures = features.replacePosition(0, [0], [10, 20]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [[10, 20], [2, 3], [3, 4]];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('replaces middle position in Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features
+      .replacePosition(0, [0, 1], [1.1, -1.1])
+      .replacePosition(0, [1, 2], [0.6, 0.6]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [
+      [[-1, -1], [1.1, -1.1], [1, 1], [-1, 1], [-1, -1]],
+      [[-0.5, -0.5], [-0.5, 0.5], [0.6, 0.6], [0.5, -0.5], [-0.5, -0.5]]
+    ];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('replaces last position when replacing first position in Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features.replacePosition(0, [0, 0], [-1.1, -1.1]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [
+      [[-1.1, -1.1], [1, -1], [1, 1], [-1, 1], [-1.1, -1.1]],
+      [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
+    ];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('replaces first position when replacing last position in Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features.replacePosition(0, [0, 4], [-1.1, -1.1]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [
+      [[-1.1, -1.1], [1, -1], [1, 1], [-1, 1], [-1.1, -1.1]],
+      [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
+    ];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+});
+
+describe('removePosition()', () => {
+  it(`doesn't mutate original`, () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [0]);
+
+    expect(updatedFeatures).not.toBe(features);
+    expect(lineStringFeature.geometry.coordinates).toEqual([[1, 2], [2, 3], [3, 4]]);
+  });
+
+  it('throws exception when attempting to remove Point', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [pointFeature]
+    });
+
+    expect(() => features.removePosition(0, [0])).toThrow(
+      `Can't remove a position from a Point or there'd be nothing left`
+    );
+  });
+
+  it('removes first position in LineString', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [0]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [[2, 3], [3, 4]];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('removes middle position in Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [0, 1]).removePosition(0, [1, 3]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [
+      [[-1, -1], [1, 1], [-1, 1], [-1, -1]],
+      [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [-0.5, -0.5]]
+    ];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('changes last position when removing first position in Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [1, 0]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [
+      [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
+      [[-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, 0.5]]
+    ];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('changes first position when removing last position in Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [1, 4]);
+
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [
+      [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
+      [[0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]
+    ];
+
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+
+  it('throws exception when LineString has only 2 positions', () => {
+    const features = new EditableFeatureCollection({
       type: 'FeatureCollection',
       features: [
-        pointFeature,
-        lineStringFeature,
-        polygonFeature,
-        multiPointFeature,
-        multiLineStringFeature,
-        multiPolygonFeature
+        { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 1], [2, 3]] } }
+      ]
+    });
+
+    expect(() => features.removePosition(0, [0])).toThrow(
+      `Can't remove position. LineString must have at least two positions`
+    );
+  });
+
+  it('throws exception when Polygon outer ring has only 4 positions (triangle)', () => {
+    let features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    features = features
+      // Convert from quadrilateral to triangle
+      .removePosition(0, [0, 1]);
+
+    expect(() => features.removePosition(0, [0, 1])).toThrow(
+      `Can't remove position. Polygon's outer ring must have at least four positions`
+    );
+  });
+
+  it('removes hole from Polygon when it has less than four positions', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [1, 1]).removePosition(0, [1, 1]);
+
+    const actualGeometry = updatedFeatures.getObject().features[0].geometry;
+    const expectedGeometry = {
+      type: 'Polygon',
+      coordinates: [[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]]
+    };
+
+    expect(actualGeometry).toEqual(expectedGeometry);
+  });
+
+  it('removes LineString from MultiLineString when it has only one position', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiLineStringFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [1, 0]).removePosition(0, [1, 0]);
+
+    const actualGeometry = updatedFeatures.getObject().features[0].geometry;
+    const expectedGeometry = {
+      type: 'MultiLineString',
+      coordinates: [[[1, 2], [2, 3], [3, 4]]]
+    };
+
+    expect(actualGeometry).toEqual(expectedGeometry);
+  });
+
+  it('throws exception when MultiLineString has only 2 positions', () => {
+    let features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiLineStringFeature]
+    });
+    features = features
+      // remove one of the LineStrings
+      .removePosition(0, [0, 0])
+      .removePosition(0, [0, 0])
+      // shrink the remaining LineString to two positions
+      .removePosition(0, [0, 0]);
+
+    expect(() => features.removePosition(0, [0, 0])).toThrow(
+      `Can't remove position. MultiLineString must have at least two positions`
+    );
+  });
+
+  it('removes Polygon from MultiPolygon when outer ring has less than four positions', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiPolygonFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [1, 0, 0]).removePosition(0, [1, 0, 0]);
+
+    const actualGeometry = updatedFeatures.getObject().features[0].geometry;
+    const expectedGeometry = {
+      type: 'MultiPolygon',
+      coordinates: [multiPolygonFeature.geometry.coordinates[0]]
+    };
+
+    expect(actualGeometry).toEqual(expectedGeometry);
+  });
+
+  it('removes hole from MultiPolygon when it has less than four positions', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiPolygonFeature]
+    });
+    const updatedFeatures = features.removePosition(0, [0, 1, 0]).removePosition(0, [0, 1, 0]);
+
+    const actualGeometry = updatedFeatures.getObject().features[0].geometry;
+    const expectedGeometry = {
+      type: 'MultiPolygon',
+      coordinates: [
+        [[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]],
+        [[[2, -1], [4, -1], [4, 1], [2, 1], [2, -1]]]
       ]
     };
+
+    expect(actualGeometry).toEqual(expectedGeometry);
   });
 
-  describe('getObject()', () => {
-    it('can get real object', () => {
-      const editable = new EditableFeatureCollection(featureCollection);
-
-      expect(editable.getObject()).toBe(featureCollection);
+  it('throws exception when MultiPolygon outer ring has only 4 positions', () => {
+    let features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiPolygonFeature]
     });
+    features = features
+      // Remove the second polygon
+      .removePosition(0, [1, 0, 0])
+      .removePosition(0, [1, 0, 0])
+      // Remove positions from outer ring
+      .removePosition(0, [0, 0, 1]);
+
+    expect(() => features.removePosition(0, [0, 0, 1])).toThrow(
+      `Can't remove position. MultiPolygon's outer ring must have at least four positions`
+    );
+  });
+});
+
+describe('addPosition()', () => {
+  it(`doesn't mutate original`, () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
+    });
+    const updatedFeatures = features.addPosition(0, [1], [2, 3]);
+
+    expect(updatedFeatures).not.toBe(features);
+    expect(lineStringFeature.geometry.coordinates).toEqual([[1, 2], [2, 3], [3, 4]]);
   });
 
-  describe('replacePosition()', () => {
-    it(`doesn't mutate original`, () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [pointFeature]
-      });
-      const updatedFeatures = features.replacePosition(0, [], [10, 20]);
-
-      expect(updatedFeatures).not.toBe(features);
-      expect(pointFeature.geometry.coordinates).toEqual([1, 2]);
+  it('throws exception when attempting to add position to Point', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [pointFeature]
     });
 
-    it('replaces position in Point', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [pointFeature]
-      });
-      const updatedFeatures = features.replacePosition(0, [], [10, 20]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [10, 20];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('replaces first position in LineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
-      const updatedFeatures = features.replacePosition(0, [0], [10, 20]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [[10, 20], [2, 3], [3, 4]];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('replaces middle position in Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features
-        .replacePosition(0, [0, 1], [1.1, -1.1])
-        .replacePosition(0, [1, 2], [0.6, 0.6]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [
-        [[-1, -1], [1.1, -1.1], [1, 1], [-1, 1], [-1, -1]],
-        [[-0.5, -0.5], [-0.5, 0.5], [0.6, 0.6], [0.5, -0.5], [-0.5, -0.5]]
-      ];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('replaces last position when replacing first position in Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features.replacePosition(0, [0, 0], [-1.1, -1.1]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [
-        [[-1.1, -1.1], [1, -1], [1, 1], [-1, 1], [-1.1, -1.1]],
-        [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
-      ];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('replaces first position when replacing last position in Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features.replacePosition(0, [0, 4], [-1.1, -1.1]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [
-        [[-1.1, -1.1], [1, -1], [1, 1], [-1, 1], [-1.1, -1.1]],
-        [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
-      ];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
+    expect(() => features.addPosition(0, [], [3, 4])).toThrow(
+      'Unable to add a position to a Point feature'
+    );
   });
 
-  describe('removePosition()', () => {
-    it(`doesn't mutate original`, () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [0]);
-
-      expect(updatedFeatures).not.toBe(features);
-      expect(lineStringFeature.geometry.coordinates).toEqual([[1, 2], [2, 3], [3, 4]]);
+  it('adds position to beginning of LineString', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
     });
+    const updatedFeatures = features.addPosition(0, [0], [10, 20]);
 
-    it('throws exception when attempting to remove Point', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [pointFeature]
-      });
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [[10, 20], [1, 2], [2, 3], [3, 4]];
 
-      expect(() => features.removePosition(0, [0])).toThrow(
-        `Can't remove a position from a Point or there'd be nothing left`
-      );
-    });
-
-    it('removes first position in LineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [0]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [[2, 3], [3, 4]];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('removes middle position in Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [0, 1]).removePosition(0, [1, 3]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [
-        [[-1, -1], [1, 1], [-1, 1], [-1, -1]],
-        [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [-0.5, -0.5]]
-      ];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('changes last position when removing first position in Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [1, 0]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [
-        [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
-        [[-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, 0.5]]
-      ];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('changes first position when removing last position in Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [1, 4]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [
-        [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
-        [[0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]
-      ];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('downgrades a LineString to a Point when it has only one position', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [
-          { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 1], [2, 3]] } }
-        ]
-      });
-      const updatedFeatures = features.removePosition(0, [1]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'Point',
-        coordinates: [0, 1]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
-
-    it('downgrades a Polygon to a LineString when it has less than four positions', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features
-        // Remove positions from outer ring
-        .removePosition(0, [0, 1])
-        .removePosition(0, [0, 1]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'LineString',
-        coordinates: [[-1, -1], [-1, 1]]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
-
-    it('removes hole from Polygon when it have less than four positions', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [1, 1]).removePosition(0, [1, 1]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'Polygon',
-        coordinates: [[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
-
-    it('removes LineString from MultiLineString when it has only one position', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiLineStringFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [1, 0]).removePosition(0, [1, 0]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'MultiLineString',
-        coordinates: [[[1, 2], [2, 3], [3, 4]]]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
-
-    it('downgrades a MultiLineString to a Point when it has only one position', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiLineStringFeature]
-      });
-      const updatedFeatures = features
-        .removePosition(0, [0, 0])
-        .removePosition(0, [0, 0])
-        .removePosition(0, [0, 0])
-        .removePosition(0, [0, 0]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'Point',
-        coordinates: [7, 8]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
-
-    it('removes Polygon from MultiPolygon when outer ring has less than four positions', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPolygonFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [1, 0, 0]).removePosition(0, [1, 0, 0]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'MultiPolygon',
-        coordinates: [multiPolygonFeature.geometry.coordinates[0]]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
-
-    it('removes hole from MultiPolygon when it has less than four positions', () => {
-      // coordinates: [
-      //     [
-      //       // exterior ring polygon 1
-      //       [[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
-      //       // hole  polygon 1
-      //       [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
-      //     ],
-      //     [
-      //       // exterior ring polygon 2
-      //       [[2, -1], [4, -1], [4, 1], [2, 1], [2, -1]]
-      //     ]
-      //   ]
-
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPolygonFeature]
-      });
-      const updatedFeatures = features.removePosition(0, [0, 1, 0]).removePosition(0, [0, 1, 0]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'MultiPolygon',
-        coordinates: [
-          [[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]],
-          [[[2, -1], [4, -1], [4, 1], [2, 1], [2, -1]]]
-        ]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
-
-    it('downgrades a MultiPolygon to a LineString when its only Polygon has less than four positions', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPolygonFeature]
-      });
-      const updatedFeatures = features
-        // Remove the second polygon
-        .removePosition(0, [1, 0, 0])
-        .removePosition(0, [1, 0, 0])
-        // Remove positions from outer ring
-        .removePosition(0, [0, 0, 1])
-        .removePosition(0, [0, 0, 1]);
-
-      const actualGeometry = updatedFeatures.getObject().features[0].geometry;
-      const expectedGeometry = {
-        type: 'LineString',
-        coordinates: [[-1, -1], [-1, 1]]
-      };
-
-      expect(actualGeometry).toEqual(expectedGeometry);
-    });
+    expect(actualCoordinates).toEqual(expectedCoordinates);
   });
 
-  describe('addPosition()', () => {
-    it(`doesn't mutate original`, () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
-      const updatedFeatures = features.addPosition(0, [1], [2, 3]);
-
-      expect(updatedFeatures).not.toBe(features);
-      expect(lineStringFeature.geometry.coordinates).toEqual([[1, 2], [2, 3], [3, 4]]);
+  it('adds position to middle of LineString', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
     });
+    const updatedFeatures = features.addPosition(0, [1], [10, 20]);
 
-    it('throws exception when attempting to add position to Point', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [pointFeature]
-      });
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [[1, 2], [10, 20], [2, 3], [3, 4]];
 
-      expect(() => features.addPosition(0, [], [3, 4])).toThrow(
-        'Unable to add a position to a Point feature'
-      );
-    });
-
-    it('adds position to beginning of LineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
-      const updatedFeatures = features.addPosition(0, [0], [10, 20]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [[10, 20], [1, 2], [2, 3], [3, 4]];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('adds position to middle of LineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
-      const updatedFeatures = features.addPosition(0, [1], [10, 20]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [[1, 2], [10, 20], [2, 3], [3, 4]];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('adds position to end of LineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
-      const updatedFeatures = features.addPosition(0, [3], [10, 20]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [[1, 2], [2, 3], [3, 4], [10, 20]];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
-
-    it('adds position in Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
-      const updatedFeatures = features
-        .addPosition(0, [0, 1], [0, -1])
-        .addPosition(0, [1, 4], [0, -0.5]);
-
-      const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
-      const expectedCoordinates = [
-        [[-1, -1], [0, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
-        [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [0, -0.5], [-0.5, -0.5]]
-      ];
-
-      expect(actualCoordinates).toEqual(expectedCoordinates);
-    });
+    expect(actualCoordinates).toEqual(expectedCoordinates);
   });
 
-  describe('addFeature()', () => {
-    it(`doesn't mutate original`, () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: []
-      });
-      features.addFeature(pointFeature);
-
-      expect(features.getObject().features.length).toEqual(0);
+  it('adds position to end of LineString', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
     });
+    const updatedFeatures = features.addPosition(0, [3], [10, 20]);
 
-    it('adds feature to empty array', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: []
-      });
-      const actualFeatures = features.addFeature(pointFeature).getObject();
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [[1, 2], [2, 3], [3, 4], [10, 20]];
 
-      const expectedFeatures = {
-        type: 'FeatureCollection',
-        features: [pointFeature]
-      };
-
-      expect(actualFeatures).toEqual(expectedFeatures);
-    });
-
-    it('adds feature to end of array', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPointFeature]
-      });
-      const actualFeatures = features.addFeature(multiLineStringFeature).getObject();
-
-      const expectedFeatures = {
-        type: 'FeatureCollection',
-        features: [multiPointFeature, multiLineStringFeature]
-      };
-
-      expect(actualFeatures).toEqual(expectedFeatures);
-    });
+    expect(actualCoordinates).toEqual(expectedCoordinates);
   });
 
-  describe('getEditHandles()', () => {
-    it('gets edit handles for Point', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [pointFeature]
-      });
+  it('adds position in Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
+    });
+    const updatedFeatures = features
+      .addPosition(0, [0, 1], [0, -1])
+      .addPosition(0, [1, 4], [0, -0.5]);
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { featureIndex: 0, position: [1, 2], positionIndexes: [], type: 'existing' }
-      ];
+    const actualCoordinates = updatedFeatures.getObject().features[0].geometry.coordinates;
+    const expectedCoordinates = [
+      [[-1, -1], [0, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]],
+      [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [0, -0.5], [-0.5, -0.5]]
+    ];
 
-      expect(actual).toEqual(expected);
+    expect(actualCoordinates).toEqual(expectedCoordinates);
+  });
+});
+
+describe('addFeature()', () => {
+  it(`doesn't mutate original`, () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: []
+    });
+    features.addFeature(pointFeature);
+
+    expect(features.getObject().features.length).toEqual(0);
+  });
+
+  it('adds feature to empty array', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: []
+    });
+    const actualFeatures = features.addFeature(pointFeature).getObject();
+
+    const expectedFeatures = {
+      type: 'FeatureCollection',
+      features: [pointFeature]
+    };
+
+    expect(actualFeatures).toEqual(expectedFeatures);
+  });
+
+  it('adds feature to end of array', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiPointFeature]
+    });
+    const actualFeatures = features.addFeature(multiLineStringFeature).getObject();
+
+    const expectedFeatures = {
+      type: 'FeatureCollection',
+      features: [multiPointFeature, multiLineStringFeature]
+    };
+
+    expect(actualFeatures).toEqual(expectedFeatures);
+  });
+});
+
+describe('getEditHandles()', () => {
+  it('gets edit handles for Point', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [pointFeature]
     });
 
-    it('gets edit handles for LineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature]
-      });
+    const actual = features.getEditHandles(0);
+    const expected = [{ featureIndex: 0, position: [1, 2], positionIndexes: [], type: 'existing' }];
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { featureIndex: 0, position: [1, 2], positionIndexes: [0], type: 'existing' },
-        { featureIndex: 0, position: [1.5, 2.5], positionIndexes: [1], type: 'intermediate' },
-        { featureIndex: 0, position: [2, 3], positionIndexes: [1], type: 'existing' },
-        { featureIndex: 0, position: [2.5, 3.5], positionIndexes: [2], type: 'intermediate' },
-        { featureIndex: 0, position: [3, 4], positionIndexes: [2], type: 'existing' }
-      ];
+    expect(actual).toEqual(expected);
+  });
 
-      expect(actual).toEqual(expected);
+  it('gets edit handles for LineString', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature]
     });
 
-    it('gets edit handles for Polygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [polygonFeature]
-      });
+    const actual = features.getEditHandles(0);
+    const expected = [
+      { featureIndex: 0, position: [1, 2], positionIndexes: [0], type: 'existing' },
+      { featureIndex: 0, position: [1.5, 2.5], positionIndexes: [1], type: 'intermediate' },
+      { featureIndex: 0, position: [2, 3], positionIndexes: [1], type: 'existing' },
+      { featureIndex: 0, position: [2.5, 3.5], positionIndexes: [2], type: 'intermediate' },
+      { featureIndex: 0, position: [3, 4], positionIndexes: [2], type: 'existing' }
+    ];
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 0], type: 'existing' },
-        { featureIndex: 0, position: [0, -1], positionIndexes: [0, 1], type: 'intermediate' },
-        { featureIndex: 0, position: [1, -1], positionIndexes: [0, 1], type: 'existing' },
-        { featureIndex: 0, position: [1, 0], positionIndexes: [0, 2], type: 'intermediate' },
-        { featureIndex: 0, position: [1, 1], positionIndexes: [0, 2], type: 'existing' },
-        { featureIndex: 0, position: [0, 1], positionIndexes: [0, 3], type: 'intermediate' },
-        { featureIndex: 0, position: [-1, 1], positionIndexes: [0, 3], type: 'existing' },
-        { featureIndex: 0, position: [-1, 0], positionIndexes: [0, 4], type: 'intermediate' },
-        { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 4], type: 'existing' },
-        { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [1, 0], type: 'existing' },
-        { featureIndex: 0, position: [-0.5, 0], positionIndexes: [1, 1], type: 'intermediate' },
-        { featureIndex: 0, position: [-0.5, 0.5], positionIndexes: [1, 1], type: 'existing' },
-        { featureIndex: 0, position: [0, 0.5], positionIndexes: [1, 2], type: 'intermediate' },
-        { featureIndex: 0, position: [0.5, 0.5], positionIndexes: [1, 2], type: 'existing' },
-        { featureIndex: 0, position: [0.5, 0], positionIndexes: [1, 3], type: 'intermediate' },
-        { featureIndex: 0, position: [0.5, -0.5], positionIndexes: [1, 3], type: 'existing' },
-        { featureIndex: 0, position: [0, -0.5], positionIndexes: [1, 4], type: 'intermediate' },
-        { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [1, 4], type: 'existing' }
-      ];
+    expect(actual).toEqual(expected);
+  });
 
-      expect(actual).toEqual(expected);
+  it('gets edit handles for Polygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [polygonFeature]
     });
 
-    it('gets edit handles for MultiPoint', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPointFeature]
-      });
+    const actual = features.getEditHandles(0);
+    const expected = [
+      { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 0], type: 'existing' },
+      { featureIndex: 0, position: [0, -1], positionIndexes: [0, 1], type: 'intermediate' },
+      { featureIndex: 0, position: [1, -1], positionIndexes: [0, 1], type: 'existing' },
+      { featureIndex: 0, position: [1, 0], positionIndexes: [0, 2], type: 'intermediate' },
+      { featureIndex: 0, position: [1, 1], positionIndexes: [0, 2], type: 'existing' },
+      { featureIndex: 0, position: [0, 1], positionIndexes: [0, 3], type: 'intermediate' },
+      { featureIndex: 0, position: [-1, 1], positionIndexes: [0, 3], type: 'existing' },
+      { featureIndex: 0, position: [-1, 0], positionIndexes: [0, 4], type: 'intermediate' },
+      { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 4], type: 'existing' },
+      { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [1, 0], type: 'existing' },
+      { featureIndex: 0, position: [-0.5, 0], positionIndexes: [1, 1], type: 'intermediate' },
+      { featureIndex: 0, position: [-0.5, 0.5], positionIndexes: [1, 1], type: 'existing' },
+      { featureIndex: 0, position: [0, 0.5], positionIndexes: [1, 2], type: 'intermediate' },
+      { featureIndex: 0, position: [0.5, 0.5], positionIndexes: [1, 2], type: 'existing' },
+      { featureIndex: 0, position: [0.5, 0], positionIndexes: [1, 3], type: 'intermediate' },
+      { featureIndex: 0, position: [0.5, -0.5], positionIndexes: [1, 3], type: 'existing' },
+      { featureIndex: 0, position: [0, -0.5], positionIndexes: [1, 4], type: 'intermediate' },
+      { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [1, 4], type: 'existing' }
+    ];
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { featureIndex: 0, position: [1, 2], positionIndexes: [0], type: 'existing' },
-        { featureIndex: 0, position: [3, 4], positionIndexes: [1], type: 'existing' }
-      ];
+    expect(actual).toEqual(expected);
+  });
 
-      expect(actual).toEqual(expected);
+  it('gets edit handles for MultiPoint', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiPointFeature]
     });
 
-    it('gets edit handles for MultiLineString', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiLineStringFeature]
-      });
+    const actual = features.getEditHandles(0);
+    const expected = [
+      { featureIndex: 0, position: [1, 2], positionIndexes: [0], type: 'existing' },
+      { featureIndex: 0, position: [3, 4], positionIndexes: [1], type: 'existing' }
+    ];
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { featureIndex: 0, position: [1, 2], positionIndexes: [0, 0], type: 'existing' },
-        { featureIndex: 0, position: [1.5, 2.5], positionIndexes: [0, 1], type: 'intermediate' },
-        { featureIndex: 0, position: [2, 3], positionIndexes: [0, 1], type: 'existing' },
-        { featureIndex: 0, position: [2.5, 3.5], positionIndexes: [0, 2], type: 'intermediate' },
-        { featureIndex: 0, position: [3, 4], positionIndexes: [0, 2], type: 'existing' },
-        { featureIndex: 0, position: [5, 6], positionIndexes: [1, 0], type: 'existing' },
-        { featureIndex: 0, position: [5.5, 6.5], positionIndexes: [1, 1], type: 'intermediate' },
-        { featureIndex: 0, position: [6, 7], positionIndexes: [1, 1], type: 'existing' },
-        { featureIndex: 0, position: [6.5, 7.5], positionIndexes: [1, 2], type: 'intermediate' },
-        { featureIndex: 0, position: [7, 8], positionIndexes: [1, 2], type: 'existing' }
-      ];
+    expect(actual).toEqual(expected);
+  });
 
-      expect(actual).toEqual(expected);
+  it('gets edit handles for MultiLineString', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiLineStringFeature]
     });
 
-    it('gets edit handles for MultiPolygon', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [multiPolygonFeature]
-      });
+    const actual = features.getEditHandles(0);
+    const expected = [
+      { featureIndex: 0, position: [1, 2], positionIndexes: [0, 0], type: 'existing' },
+      { featureIndex: 0, position: [1.5, 2.5], positionIndexes: [0, 1], type: 'intermediate' },
+      { featureIndex: 0, position: [2, 3], positionIndexes: [0, 1], type: 'existing' },
+      { featureIndex: 0, position: [2.5, 3.5], positionIndexes: [0, 2], type: 'intermediate' },
+      { featureIndex: 0, position: [3, 4], positionIndexes: [0, 2], type: 'existing' },
+      { featureIndex: 0, position: [5, 6], positionIndexes: [1, 0], type: 'existing' },
+      { featureIndex: 0, position: [5.5, 6.5], positionIndexes: [1, 1], type: 'intermediate' },
+      { featureIndex: 0, position: [6, 7], positionIndexes: [1, 1], type: 'existing' },
+      { featureIndex: 0, position: [6.5, 7.5], positionIndexes: [1, 2], type: 'intermediate' },
+      { featureIndex: 0, position: [7, 8], positionIndexes: [1, 2], type: 'existing' }
+    ];
 
-      const actual = features.getEditHandles(0);
-      const expected = [
-        { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 0, 0], type: 'existing' },
-        { featureIndex: 0, position: [0, -1], positionIndexes: [0, 0, 1], type: 'intermediate' },
-        { featureIndex: 0, position: [1, -1], positionIndexes: [0, 0, 1], type: 'existing' },
-        { featureIndex: 0, position: [1, 0], positionIndexes: [0, 0, 2], type: 'intermediate' },
-        { featureIndex: 0, position: [1, 1], positionIndexes: [0, 0, 2], type: 'existing' },
-        { featureIndex: 0, position: [0, 1], positionIndexes: [0, 0, 3], type: 'intermediate' },
-        { featureIndex: 0, position: [-1, 1], positionIndexes: [0, 0, 3], type: 'existing' },
-        { featureIndex: 0, position: [-1, 0], positionIndexes: [0, 0, 4], type: 'intermediate' },
-        { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 0, 4], type: 'existing' },
-        { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [0, 1, 0], type: 'existing' },
-        { featureIndex: 0, position: [-0.5, 0], positionIndexes: [0, 1, 1], type: 'intermediate' },
-        { featureIndex: 0, position: [-0.5, 0.5], positionIndexes: [0, 1, 1], type: 'existing' },
-        { featureIndex: 0, position: [0, 0.5], positionIndexes: [0, 1, 2], type: 'intermediate' },
-        { featureIndex: 0, position: [0.5, 0.5], positionIndexes: [0, 1, 2], type: 'existing' },
-        { featureIndex: 0, position: [0.5, 0], positionIndexes: [0, 1, 3], type: 'intermediate' },
-        { featureIndex: 0, position: [0.5, -0.5], positionIndexes: [0, 1, 3], type: 'existing' },
-        { featureIndex: 0, position: [0, -0.5], positionIndexes: [0, 1, 4], type: 'intermediate' },
-        { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [0, 1, 4], type: 'existing' },
-        { featureIndex: 0, position: [2, -1], positionIndexes: [1, 0, 0], type: 'existing' },
-        { featureIndex: 0, position: [3, -1], positionIndexes: [1, 0, 1], type: 'intermediate' },
-        { featureIndex: 0, position: [4, -1], positionIndexes: [1, 0, 1], type: 'existing' },
-        { featureIndex: 0, position: [4, 0], positionIndexes: [1, 0, 2], type: 'intermediate' },
-        { featureIndex: 0, position: [4, 1], positionIndexes: [1, 0, 2], type: 'existing' },
-        { featureIndex: 0, position: [3, 1], positionIndexes: [1, 0, 3], type: 'intermediate' },
-        { featureIndex: 0, position: [2, 1], positionIndexes: [1, 0, 3], type: 'existing' },
-        { featureIndex: 0, position: [2, 0], positionIndexes: [1, 0, 4], type: 'intermediate' },
-        { featureIndex: 0, position: [2, -1], positionIndexes: [1, 0, 4], type: 'existing' }
-      ];
+    expect(actual).toEqual(expected);
+  });
 
-      expect(actual).toEqual(expected);
+  it('gets edit handles for MultiPolygon', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [multiPolygonFeature]
     });
 
-    it('gets edit handles for MultiPoint in multi-feature collection', () => {
-      const features = new EditableFeatureCollection({
-        type: 'FeatureCollection',
-        features: [lineStringFeature, multiPointFeature]
-      });
+    const actual = features.getEditHandles(0);
+    const expected = [
+      { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 0, 0], type: 'existing' },
+      { featureIndex: 0, position: [0, -1], positionIndexes: [0, 0, 1], type: 'intermediate' },
+      { featureIndex: 0, position: [1, -1], positionIndexes: [0, 0, 1], type: 'existing' },
+      { featureIndex: 0, position: [1, 0], positionIndexes: [0, 0, 2], type: 'intermediate' },
+      { featureIndex: 0, position: [1, 1], positionIndexes: [0, 0, 2], type: 'existing' },
+      { featureIndex: 0, position: [0, 1], positionIndexes: [0, 0, 3], type: 'intermediate' },
+      { featureIndex: 0, position: [-1, 1], positionIndexes: [0, 0, 3], type: 'existing' },
+      { featureIndex: 0, position: [-1, 0], positionIndexes: [0, 0, 4], type: 'intermediate' },
+      { featureIndex: 0, position: [-1, -1], positionIndexes: [0, 0, 4], type: 'existing' },
+      { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [0, 1, 0], type: 'existing' },
+      { featureIndex: 0, position: [-0.5, 0], positionIndexes: [0, 1, 1], type: 'intermediate' },
+      { featureIndex: 0, position: [-0.5, 0.5], positionIndexes: [0, 1, 1], type: 'existing' },
+      { featureIndex: 0, position: [0, 0.5], positionIndexes: [0, 1, 2], type: 'intermediate' },
+      { featureIndex: 0, position: [0.5, 0.5], positionIndexes: [0, 1, 2], type: 'existing' },
+      { featureIndex: 0, position: [0.5, 0], positionIndexes: [0, 1, 3], type: 'intermediate' },
+      { featureIndex: 0, position: [0.5, -0.5], positionIndexes: [0, 1, 3], type: 'existing' },
+      { featureIndex: 0, position: [0, -0.5], positionIndexes: [0, 1, 4], type: 'intermediate' },
+      { featureIndex: 0, position: [-0.5, -0.5], positionIndexes: [0, 1, 4], type: 'existing' },
+      { featureIndex: 0, position: [2, -1], positionIndexes: [1, 0, 0], type: 'existing' },
+      { featureIndex: 0, position: [3, -1], positionIndexes: [1, 0, 1], type: 'intermediate' },
+      { featureIndex: 0, position: [4, -1], positionIndexes: [1, 0, 1], type: 'existing' },
+      { featureIndex: 0, position: [4, 0], positionIndexes: [1, 0, 2], type: 'intermediate' },
+      { featureIndex: 0, position: [4, 1], positionIndexes: [1, 0, 2], type: 'existing' },
+      { featureIndex: 0, position: [3, 1], positionIndexes: [1, 0, 3], type: 'intermediate' },
+      { featureIndex: 0, position: [2, 1], positionIndexes: [1, 0, 3], type: 'existing' },
+      { featureIndex: 0, position: [2, 0], positionIndexes: [1, 0, 4], type: 'intermediate' },
+      { featureIndex: 0, position: [2, -1], positionIndexes: [1, 0, 4], type: 'existing' }
+    ];
 
-      const actual = features.getEditHandles(1);
-      const expected = [
-        { featureIndex: 1, position: [1, 2], positionIndexes: [0], type: 'existing' },
-        { featureIndex: 1, position: [3, 4], positionIndexes: [1], type: 'existing' }
-      ];
+    expect(actual).toEqual(expected);
+  });
 
-      expect(actual).toEqual(expected);
+  it('gets edit handles for MultiPoint in multi-feature collection', () => {
+    const features = new EditableFeatureCollection({
+      type: 'FeatureCollection',
+      features: [lineStringFeature, multiPointFeature]
     });
+
+    const actual = features.getEditHandles(1);
+    const expected = [
+      { featureIndex: 1, position: [1, 2], positionIndexes: [0], type: 'existing' },
+      { featureIndex: 1, position: [3, 4], positionIndexes: [1], type: 'existing' }
+    ];
+
+    expect(actual).toEqual(expected);
   });
 });


### PR DESCRIPTION
The first part of the [upcoming tentative feature functionality](https://github.com/uber/nebula.gl/pull/71), we no longer want to have nebula change geometry type based on edits.

An example of how it works today:
* **Given**: Triangle polygon with a triangle hole inside it
* **When**: User clicks a point of the hole
* **Then**: Polygon no longer has a hole (because you can't have a Polygon with a LineString hole)
* **When**: User clicks a point of the outer ring
* **Then**: Polygon is downgraded to a LineString with two points (because you can't have a Polygon with only 2 points, and nebula assumes you want to downgrade)
* **When**: User clicks one of the points
* **Then**: LineString is downgraded to a Point
* **When**: User clicks the point
* **Then**: Nothing happens (nebula doesn't assume user wants to remove the feature entirely)

After this change, this is how it would work:
* **Given**: Triangle polygon with a triangle hole inside it
* **When**: User clicks a point of the hole
* **Then**: Polygon no longer has a hole (because you can't have a Polygon with a LineString hole)
* **When**: User clicks a point of the outer ring
* **Then**: Nothing happens (nebula doesn't assume user wants to downgrade the geometry type)

So, generally:
* a Point or MultiPoint will be simplified all the way down to a single point, but no further
* a LineString or MultiLineString will be simplified all the way down to a 2-point line, but no further
* a Polygon or MultiPolygon will be simplified all the way down to a triangle, but no further

Dependent on #79