### PR TITLE
Duplicate a feature

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -97,6 +97,8 @@ The `mode` property dictates what type of edits the user can perform and how to 
 
 * If action: `transformTranslate` means the feature can be moved by mouse pointer down hold and drag to required direction.
 
+* If action: `duplicate` means the feature can be copied and moved by mouse pointer down hold and drag to required direction.
+
 * If action: `transformRotate` means the feature will be transform rotated by default the pivot as centroid.
 
 * If pivot: [120, 5] means the point is used as pivot for rotate. if the value is null or undefined then pivot is centroid.

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -274,7 +274,7 @@ export default class Example extends Component<
       selectedFeatureIndexes,
       mode,
       modeConfig: {
-        action: keyHolded === 'Control' ? 'transformRotate' : 'transformTranslate',
+        action: keyHolded === 'Shift' ? 'duplicate' : 'transformTranslate',
         usePickAsPivot: true,
         pivot: undefined
       },

--- a/modules/core/src/lib/editable-feature-collection.js
+++ b/modules/core/src/lib/editable-feature-collection.js
@@ -323,6 +323,10 @@ export class EditableFeatureCollection {
     };
   }
 
+  getAddFeatureEditAction(geometry: Geometry): EditAction {
+    return this._getAddFeatureEditAction(geometry);
+  }
+
   onPointerMove(groundCoords: Position): void {
     if (this._mode === 'drawLineString') {
       this._handlePointerMoveForDrawLineString(groundCoords);

--- a/modules/core/src/lib/layers/editable-geojson-layer.js
+++ b/modules/core/src/lib/layers/editable-geojson-layer.js
@@ -442,6 +442,31 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     }
   }
 
+  onPointerDown({
+    screenCoords,
+    groundCoords,
+    sourceEvent
+  }: {
+    screenCoords: Position,
+    groundCoords: Position,
+    sourceEvent: any
+  }) {
+    const isDuplicateFeature =
+      this.props.mode === 'modify' &&
+      this.props.modeConfig &&
+      this.props.modeConfig.action === 'duplicate';
+    const feature = this.state.selectedFeatures[0];
+    if (isDuplicateFeature) {
+      const editAction = this.state.editableFeatureCollection.getAddFeatureEditAction(
+        feature.geometry
+      );
+
+      if (editAction) {
+        this.props.onEdit(editAction);
+      }
+    }
+  }
+
   onPointerMove({
     picks,
     screenCoords,
@@ -460,7 +485,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     const isTranslateFeature =
       this.props.mode === 'modify' &&
       this.props.modeConfig &&
-      this.props.modeConfig.action === 'transformTranslate';
+      ['transformTranslate', 'duplicate'].includes(this.props.modeConfig.action);
     let distanceMoved = 0.02;
     const { pointerMovePicks } = this.state;
     if (

--- a/modules/core/src/lib/layers/editable-layer.js
+++ b/modules/core/src/lib/layers/editable-layer.js
@@ -45,6 +45,10 @@ export default class EditableLayer extends CompositeLayer {
     // default implementation - do nothing
   }
 
+  onPointerDown({ screenCoords, groundCoords, sourceEvent }: Object) {
+    // default implementation - do nothing
+  }
+
   onPointerMove({ screenCoords, groundCoords, isDragging, sourceEvent }: Object) {
     // default implementation - do nothing
   }
@@ -155,6 +159,11 @@ export default class EditableLayer extends CompositeLayer {
         pointerDownPicks: picks,
         isDragging: false
       }
+    });
+    this.onPointerDown({
+      screenCoords,
+      groundCoords,
+      sourceEvent: event
     });
   }
 

--- a/modules/core/src/test/lib/editable-feature-collection.test.js
+++ b/modules/core/src/test/lib/editable-feature-collection.test.js
@@ -95,6 +95,15 @@ describe('getFeatureCollection()', () => {
   });
 });
 
+describe('getAddFeatureEditAction()', () => {
+  it('get add feature edit action', () => {
+    const editable = new EditableFeatureCollection(featureCollection);
+    const editAction = editable.getAddFeatureEditAction(polygonFeature.geometry);
+
+    expect(editAction.editType).toBe('addFeature');
+  });
+});
+
 describe('setFeatureCollection()', () => {
   it('immutably updates feature collection', () => {
     const featureCollection1 = {


### PR DESCRIPTION
In modify mode with action "duplicate", drag the selected feature will duplicated and move.
![nebula-duplicate-feature](https://user-images.githubusercontent.com/1399914/46278240-34ade780-c583-11e8-9e08-420bbd6c2e5e.gif)
