### PR TITLE
Ability to move feature in new cursor mode

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -67,6 +67,8 @@ The `mode` property dictates what type of edits the user can perform and how to 
 
 * `view`: no edits are possible, but selection is still possible.
 
+* `cursor`: When user selected any feature, The bounding box will be drawn for the feature. Currently modeConfig.action: `transformTranslate` is available.
+
 * `modify`: user can move existing points, add intermediate points along lines, and remove points.
 
 * `drawPoint`: user can draw a new `Point` feature by clicking where the point is to be.
@@ -95,7 +97,7 @@ The `mode` property dictates what type of edits the user can perform and how to 
 
 #### `modeConfig` (Object, optional)
 
-* If action: `transformTranslate` means the feature can be moved by mouse pointer down hold and drag to required direction.
+* In `cursor` mode, If action: `transformTranslate` means the feature can be moved by mouse pointer down hold and drag to required direction.
 
 * If action: `transformRotate` means the feature will be transform rotated by default the pivot as centroid.
 

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -95,6 +95,8 @@ The `mode` property dictates what type of edits the user can perform and how to 
 
 #### `modeConfig` (Object, optional)
 
+* If action: `transformTranslate` means the feature can be moved by mouse pointer down hold and drag to required direction.
+
 * If action: `transformRotate` means the feature will be transform rotated by default the pivot as centroid.
 
 * If pivot: [120, 5] means the point is used as pivot for rotate. if the value is null or undefined then pivot is centroid.

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -275,7 +275,7 @@ export default class Example extends Component<
       selectedFeatureIndexes,
       mode,
       modeConfig: {
-        action: keyHolded === 'Control' ? 'transformRotate' : 'none',
+        action: keyHolded === 'Control' ? 'transformRotate' : 'transformTranslate',
         usePickAsPivot: true,
         pivot: undefined
       },

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -349,7 +349,12 @@ export default class Example extends Component<
 
       // customize tentative feature style
       getTentativeLineDashArray: () => [7, 4],
-      getTentativeLineColor: () => [0x8f, 0x8f, 0x8f, 0xff]
+      getTentativeLineColor: () => [0x8f, 0x8f, 0x8f, 0xff],
+
+      // customize cursor mode bounding box selection feature style
+      getCursorBoundingBoxLineColor: () => [0x8f, 0x8f, 0x8f, 0xff],
+      getCursorBoundingBoxLineWidth: () => 2,
+      getCursorBoundingBoxFillColor: () => [0, 0, 0, 0.1]
     });
 
     return (

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -202,6 +202,7 @@ export default class Example extends Component<
             >
               <option value="view">view</option>
               <option value="modify">modify</option>
+              <option value="cursor">cursor</option>
               <option value="drawPoint">drawPoint</option>
               <option value="drawLineString">drawLineString</option>
               <option value="drawPolygon">drawPolygon</option>

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -56,6 +56,7 @@
     "@turf/nearest-point-on-line": ">=4.0.0",
     "@turf/point-to-line-distance": ">=4.0.0",
     "@turf/transform-rotate": ">=4.0.0",
+    "@turf/transform-translate": ">=4.0.0",
     "cubic-hermite-spline": "^1.0.1",
     "deck.gl": "^6.1.1",
     "geojson-types": "^2.0.1",

--- a/modules/core/src/lib/editable-feature-collection.js
+++ b/modules/core/src/lib/editable-feature-collection.js
@@ -114,6 +114,15 @@ export class EditableFeatureCollection {
       return handles;
     }
 
+    if (this._mode === 'cursor') {
+      for (const index of this._selectedFeatureIndexes) {
+        const feature = this.featureCollection.getObject().features[index];
+        const bbox = bboxPolygon(turfBbox(feature));
+        handles = handles.concat(getEditHandlesForGeometry(bbox.geometry, index));
+      }
+      return handles;
+    }
+
     for (const index of this._selectedFeatureIndexes) {
       const geometry = this.featureCollection.getObject().features[index].geometry;
       handles = handles.concat(getEditHandlesForGeometry(geometry, index));
@@ -194,7 +203,7 @@ export class EditableFeatureCollection {
   getEditBoundingBoxes(): Feature[] {
     let bboxes = [];
 
-    if (this._mode !== 'modify') {
+    if (this._mode !== 'cursor') {
       return bboxes;
     }
 

--- a/modules/core/src/lib/editable-feature-collection.js
+++ b/modules/core/src/lib/editable-feature-collection.js
@@ -1,6 +1,7 @@
 // @flow
 
 import nearestPointOnLine from '@turf/nearest-point-on-line';
+import turfBbox from '@turf/bbox';
 import bboxPolygon from '@turf/bbox-polygon';
 import circle from '@turf/circle';
 import distance from '@turf/distance';
@@ -13,12 +14,12 @@ import { point, lineString as toLineString } from '@turf/helpers';
 
 import type {
   FeatureCollection,
-    Feature,
-    Geometry,
-    Point,
-    LineString,
-    Polygon,
-    Position
+  Feature,
+  Geometry,
+  Point,
+  LineString,
+  Polygon,
+  Position
 } from '../geojson-types.js';
 
 import { recursivelyTraverseNestedArrays } from './utils';
@@ -188,6 +189,21 @@ export class EditableFeatureCollection {
     }
 
     return handles;
+  }
+
+  getEditBoundingBoxes(): Feature[] {
+    let bboxes = [];
+
+    if (this._mode !== 'modify') {
+      return bboxes;
+    }
+
+    for (const index of this._selectedFeatureIndexes) {
+      const feature = this.featureCollection.getObject().features[index];
+      bboxes = bboxes.concat(bboxPolygon(turfBbox(feature)));
+    }
+
+    return bboxes;
   }
 
   getTentativeFeature(): ?Feature {

--- a/modules/core/src/lib/layers/editable-geojson-layer.js
+++ b/modules/core/src/lib/layers/editable-geojson-layer.js
@@ -512,7 +512,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       this.props.mode === 'modify' &&
       this.props.modeConfig &&
       this.props.modeConfig.action === 'transformTranslate';
-    let distanceMoved = 0.02;
+    let distanceMoved;
     const { pointerMovePicks } = this.state;
     if (
       isTranslateFeature &&
@@ -521,15 +521,12 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       picks &&
       picks.length
     ) {
-      distanceMoved = Math.max(
-        turfDistance(point(pointerMovePicks[0].lngLat), point(picks[0].lngLat)),
-        0.02
-      );
+      distanceMoved = turfDistance(point(pointerMovePicks[0].lngLat), point(picks[0].lngLat));
     }
     this.setState({ pointerMovePicks: picks });
 
     if (pointerDownPicks && pointerDownPicks.length > 0) {
-      if (isTranslateFeature) {
+      if (isTranslateFeature && distanceMoved) {
         sourceEvent.stopPropagation();
         this.handleTransformTranslate(screenCoords, groundCoords, pointerDownPicks, distanceMoved);
         return;

--- a/modules/core/src/lib/layers/editable-geojson-layer.js
+++ b/modules/core/src/lib/layers/editable-geojson-layer.js
@@ -3,6 +3,9 @@
 
 import { GeoJsonLayer, ScatterplotLayer, IconLayer } from 'deck.gl';
 import turfTransformRotate from '@turf/transform-rotate';
+import turfTransformTranslate from '@turf/transform-translate';
+import turfDistance from '@turf/distance';
+import { point } from '@turf/helpers';
 import { EditableFeatureCollection } from '../editable-feature-collection.js';
 import type { EditAction } from '../editable-feature-collection.js';
 import type { Feature, Position } from '../../geojson-types.js';
@@ -505,9 +508,32 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     pointerDownPicks: any[],
     sourceEvent: any
   }) {
+    const isTranslateFeature =
+      this.props.mode === 'modify' &&
+      this.props.modeConfig &&
+      this.props.modeConfig.action === 'transformTranslate';
+    let distanceMoved = 0.02;
+    const { pointerMovePicks } = this.state;
+    if (
+      isTranslateFeature &&
+      pointerMovePicks &&
+      pointerMovePicks.length &&
+      picks &&
+      picks.length
+    ) {
+      distanceMoved = Math.max(
+        turfDistance(point(pointerMovePicks[0].lngLat), point(picks[0].lngLat)),
+        0.02
+      );
+    }
     this.setState({ pointerMovePicks: picks });
 
     if (pointerDownPicks && pointerDownPicks.length > 0) {
+      if (isTranslateFeature) {
+        sourceEvent.stopPropagation();
+        this.handleTransformTranslate(screenCoords, groundCoords, pointerDownPicks, distanceMoved);
+        return;
+      }
       const editHandleInfo = this.getPickedEditHandle(pointerDownPicks);
       if (editHandleInfo) {
         // TODO: find a less hacky way to prevent map panning
@@ -561,6 +587,38 @@ export default class EditableGeoJsonLayer extends EditableLayer {
 
     this.props.onEdit({
       updatedData,
+      editType: 'transformPosition',
+      featureIndex,
+      positionIndexes: this.props.positionIndexes,
+      position: groundCoords
+    });
+  }
+
+  handleTransformTranslate(
+    screenCoords: Position,
+    groundCoords: Position,
+    pointerDownPicks: any[],
+    distanceMoved: number
+  ) {
+    const featureIndex = this.props.selectedFeatureIndexes[0];
+    const feature = this.state.selectedFeatures[0];
+    const p1 = { x: screenCoords[0], y: screenCoords[1] };
+    const p2 = { x: pointerDownPicks[0].x, y: pointerDownPicks[0].y };
+    const angleFromNorth = (pointA, pointB) => {
+      const angleFromWest = (Math.atan2(pointA.y - pointB.y, pointA.x - pointB.x) * 180) / Math.PI;
+      return angleFromWest > 90 && angleFromWest < 180 ? angleFromWest - 90 : angleFromWest + 270;
+    };
+    const direction = angleFromNorth(p2, p1);
+    const movedFeature = turfTransformTranslate(feature, distanceMoved, direction);
+
+    const updatedData = this.state.editableFeatureCollection.featureCollection
+      .replaceGeometry(featureIndex, movedFeature.geometry)
+      .getObject();
+
+    this.props.onEdit({
+      updatedData,
+      updatedMode: this.props.mode,
+      updatedSelectedFeatureIndexes: this.props.selectedFeatureIndexes,
       editType: 'transformPosition',
       featureIndex,
       positionIndexes: this.props.positionIndexes,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,7 +1047,7 @@
     "@turf/rhumb-destination" "^5.1.5"
     "@turf/rhumb-distance" "^5.1.5"
 
-"@turf/transform-translate@^5.1.5":
+"@turf/transform-translate@>=4.0.0":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/transform-translate/-/transform-translate-5.1.5.tgz#530a257fb1dc7268dadcab34e67901eb2a3dec63"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,6 +1047,16 @@
     "@turf/rhumb-destination" "^5.1.5"
     "@turf/rhumb-distance" "^5.1.5"
 
+"@turf/transform-translate@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/transform-translate/-/transform-translate-5.1.5.tgz#530a257fb1dc7268dadcab34e67901eb2a3dec63"
+  dependencies:
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+    "@turf/rhumb-destination" "^5.1.5"
+
 abab@^1.0.3, abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"


### PR DESCRIPTION
@georgios-uber @supersonicclay, I have fixed the issues with move feature. 
Adding the new "cursor" mode,  In this mode the feature selections will have bounding box to feature.
With this user can move, duplicate, resize, (may be rotate) etc. (currently this PR will have "move" feature). 

Scenario: Select mode as "cursor" -> Select any feature -> mouse click + hold on feature and drag to move to desired location.

![nebula-move-feature-2](https://user-images.githubusercontent.com/1399914/46422217-7a200f80-c751-11e8-8006-f8ac1bcfbad4.gif)
