### PR TITLE
New cursor mode, the selection will be bounding box

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -67,6 +67,8 @@ The `mode` property dictates what type of edits the user can perform and how to 
 
 * `view`: no edits are possible, but selection is still possible.
 
+* `cursor`: When user selected any feature, The bounding box will be drawn for the feature. 
+
 * `modify`: user can move existing points, add intermediate points along lines, and remove points.
 
 * `drawPoint`: user can draw a new `Point` feature by clicking where the point is to be.

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -349,7 +349,12 @@ export default class Example extends Component<
 
       // customize tentative feature style
       getTentativeLineDashArray: () => [7, 4],
-      getTentativeLineColor: () => [0x8f, 0x8f, 0x8f, 0xff]
+      getTentativeLineColor: () => [0x8f, 0x8f, 0x8f, 0xff],
+
+      // customize cursor mode bounding box selection feature style
+      getCursorBoundingBoxLineColor: () => [0x8f, 0x8f, 0x8f, 0xff],
+      getCursorBoundingBoxLineWidth: () => 2,
+      getCursorBoundingBoxFillColor: () => [0, 0, 0, 0.1]
     });
 
     return (

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -202,6 +202,7 @@ export default class Example extends Component<
             >
               <option value="view">view</option>
               <option value="modify">modify</option>
+              <option value="cursor">cursor</option>
               <option value="drawPoint">drawPoint</option>
               <option value="drawLineString">drawLineString</option>
               <option value="drawPolygon">drawPolygon</option>

--- a/modules/core/src/lib/editable-feature-collection.js
+++ b/modules/core/src/lib/editable-feature-collection.js
@@ -114,6 +114,15 @@ export class EditableFeatureCollection {
       return handles;
     }
 
+    if (this._mode === 'cursor') {
+      for (const index of this._selectedFeatureIndexes) {
+        const feature = this.featureCollection.getObject().features[index];
+        const bbox = bboxPolygon(turfBbox(feature));
+        handles = handles.concat(getEditHandlesForGeometry(bbox.geometry, index));
+      }
+      return handles;
+    }
+
     for (const index of this._selectedFeatureIndexes) {
       const geometry = this.featureCollection.getObject().features[index].geometry;
       handles = handles.concat(getEditHandlesForGeometry(geometry, index));
@@ -194,7 +203,7 @@ export class EditableFeatureCollection {
   getEditBoundingBoxes(): Feature[] {
     let bboxes = [];
 
-    if (this._mode !== 'modify') {
+    if (this._mode !== 'cursor') {
       return bboxes;
     }
 

--- a/modules/core/src/lib/editable-feature-collection.js
+++ b/modules/core/src/lib/editable-feature-collection.js
@@ -1,6 +1,7 @@
 // @flow
 
 import nearestPointOnLine from '@turf/nearest-point-on-line';
+import turfBbox from '@turf/bbox';
 import bboxPolygon from '@turf/bbox-polygon';
 import circle from '@turf/circle';
 import distance from '@turf/distance';
@@ -13,12 +14,12 @@ import { point, lineString as toLineString } from '@turf/helpers';
 
 import type {
   FeatureCollection,
-    Feature,
-    Geometry,
-    Point,
-    LineString,
-    Polygon,
-    Position
+  Feature,
+  Geometry,
+  Point,
+  LineString,
+  Polygon,
+  Position
 } from '../geojson-types.js';
 
 import { recursivelyTraverseNestedArrays } from './utils';
@@ -188,6 +189,21 @@ export class EditableFeatureCollection {
     }
 
     return handles;
+  }
+
+  getEditBoundingBoxes(): Feature[] {
+    let bboxes = [];
+
+    if (this._mode !== 'modify') {
+      return bboxes;
+    }
+
+    for (const index of this._selectedFeatureIndexes) {
+      const feature = this.featureCollection.getObject().features[index];
+      bboxes = bboxes.concat(bboxPolygon(turfBbox(feature)));
+    }
+
+    return bboxes;
   }
 
   getTentativeFeature(): ?Feature {

--- a/modules/core/src/lib/layers/editable-geojson-layer.js
+++ b/modules/core/src/lib/layers/editable-geojson-layer.js
@@ -339,15 +339,9 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         pointRadiusMinPixels: this.props.editHandlePointRadiusMinPixels,
         pointRadiusMaxPixels: this.props.editHandlePointRadiusMaxPixels,
         getRadius: this.props.getEditHandlePointRadius,
-        getLineColor: feature => this.props.getTentativeLineColor(feature, this.props.mode),
-        getLineWidth: feature => this.props.getTentativeLineWidth(feature, this.props.mode),
-        getFillColor: feature => this.props.getTentativeFillColor(feature, this.props.mode),
-        getLineDashArray: feature =>
-          this.props.getTentativeLineDashArray(
-            feature,
-            this.state.selectedFeatures[0],
-            this.props.mode
-          )
+        getLineColor: feature => this.props.getCursorBoundingBoxLineColor(feature, this.props.mode),
+        getLineWidth: feature => this.props.getCursorBoundingBoxLineWidth(feature, this.props.mode),
+        getFillColor: feature => this.props.getCursorBoundingBoxFillColor(feature, this.props.mode)
       })
     );
 
@@ -387,6 +381,9 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     screenCoords: Position,
     groundCoords: Position
   }) {
+    if (this.props.mode === 'cursor') {
+      return;
+    }
     const editHandleInfo = this.getPickedEditHandle(picks);
     const editHandle = editHandleInfo ? editHandleInfo.object : null;
 
@@ -446,7 +443,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
   }) {
     const { selectedFeatures } = this.state;
 
-    if (!selectedFeatures.length) {
+    if (!selectedFeatures.length || this.props.mode === 'cursor') {
       return;
     }
 
@@ -475,7 +472,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
   }) {
     const { selectedFeatures } = this.state;
 
-    if (!selectedFeatures.length) {
+    if (!selectedFeatures.length || this.props.mode === 'cursor') {
       return;
     }
 


### PR DESCRIPTION
The mode 'cursor' is added. With this mode when feature is selected, the bounding box will drawn. This will be useful to add more edit feature capabilities like move, rotate, expand and resize etc.
![nebula-cursor-mode](https://user-images.githubusercontent.com/1399914/46471130-9924ad00-c7f6-11e8-935c-b331a521f4dd.gif)
