### PR TITLE
Ability to translate a feature. (with ModeHandler)

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -131,6 +131,10 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `rotated`: A feature finished rotating (e.g. user finished dragging).
 
+  * `translating`: A feature is being translated.
+
+  * `translated`: A feature finished translating (e.g. user finished dragging).
+
 * `featureIndex` (Number): The index of the edited/added feature.
 
 * `positionIndexes` (Array): An array of numbers representing the indexes of the edited position within the features' `coordinates` array

--- a/docs/api-reference/mode-handlers/overview.md
+++ b/docs/api-reference/mode-handlers/overview.md
@@ -24,6 +24,14 @@ User can rotate a feature about its centroid by clicking and dragging the select
 
 _Note: currently only supports single selection_
 
+## [TranslateHandler](https://github.com/uber/nebula.gl/blob/master/modules/core/src/lib/mode-handlers/translate-handler.js)
+
+* Mode name: `translate`
+
+User can translate a feature by clicking selected feature and dragging anywhere on the screen.
+
+_Note: currently only supports single selection_
+
 ## [DrawPointHandler](https://github.com/uber/nebula.gl/blob/master/modules/core/src/lib/mode-handlers/draw-point-handler.js)
 
 * Mode name: `drawPoint`

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -197,6 +197,7 @@ export default class Example extends Component<
             >
               <option value="view">view</option>
               <option value="modify">modify</option>
+              <option value="translate">translate</option>
               <option value="rotate">rotate</option>
               <option value="drawPoint">drawPoint</option>
               <option value="drawLineString">drawLineString</option>

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -59,6 +59,7 @@
     "@turf/point-to-line-distance": ">=4.0.0",
     "@turf/transform-rotate": ">=4.0.0",
     "@turf/union": ">=4.0.0",
+    "@turf/transform-translate": ">=4.0.0",
     "cubic-hermite-spline": "^1.0.1",
     "deck.gl": "^6.1.1",
     "geojson-types": "^2.0.1",

--- a/modules/core/src/lib/layers/editable-geojson-layer.js
+++ b/modules/core/src/lib/layers/editable-geojson-layer.js
@@ -5,6 +5,7 @@ import { GeoJsonLayer, ScatterplotLayer, IconLayer } from 'deck.gl';
 import { ModeHandler } from '../mode-handlers/mode-handler.js';
 import { ViewHandler } from '../mode-handlers/view-handler.js';
 import { ModifyHandler } from '../mode-handlers/modify-handler.js';
+import { TranslateHandler } from '../mode-handlers/translate-handler.js';
 import { RotateHandler } from '../mode-handlers/rotate-handler.js';
 import { DrawPointHandler } from '../mode-handlers/draw-point-handler.js';
 import { DrawLineStringHandler } from '../mode-handlers/draw-line-string-handler.js';
@@ -101,6 +102,7 @@ const defaultProps = {
     view: new ViewHandler(),
     modify: new ModifyHandler(),
     rotate: new RotateHandler(),
+    translate: new TranslateHandler(),
     drawPoint: new DrawPointHandler(),
     drawLineString: new DrawLineStringHandler(),
     drawPolygon: new DrawPolygonHandler(),

--- a/modules/core/src/lib/mode-handlers/translate-handler.js
+++ b/modules/core/src/lib/mode-handlers/translate-handler.js
@@ -1,0 +1,105 @@
+// @flow
+
+import turfBearing from '@turf/bearing';
+import turfDistance from '@turf/distance';
+import turfTransformTranslate from '@turf/transform-translate';
+import { point } from '@turf/helpers';
+import type { Geometry, Position } from '../../geojson-types.js';
+import type { PointerMoveEvent, StartDraggingEvent, StopDraggingEvent } from '../event-types.js';
+import type { EditAction } from './mode-handler.js';
+import { ModeHandler } from './mode-handler.js';
+
+export class TranslateHandler extends ModeHandler {
+  _geometryBeforeTranslate: ?Geometry;
+
+  handlePointerMove(event: PointerMoveEvent): { editAction: ?EditAction, cancelMapPan: boolean } {
+    let editAction: ?EditAction = null;
+    let cancelMapPan = false;
+
+    const selectedFeatureIndexes = this.getSelectedFeatureIndexes();
+
+    if (
+      event.isDragging &&
+      event.pointerDownGroundCoords &&
+      this._geometryBeforeTranslate &&
+      selectedFeatureIndexes.length === 1
+    ) {
+      // Translate the geometry
+      editAction = this.getEditAction(event.pointerDownGroundCoords, event.groundCoords);
+    }
+
+    if (
+      event.pointerDownGroundCoords &&
+      event.pointerDownPicks &&
+      event.pointerDownPicks.length &&
+      event.pointerDownPicks[0].index === selectedFeatureIndexes[0]
+    ) {
+      cancelMapPan = true;
+    }
+
+    return { editAction, cancelMapPan };
+  }
+
+  handleStartDragging(event: StartDraggingEvent): ?EditAction {
+    const selectedFeatureIndexes = this.getSelectedFeatureIndexes();
+    const geometryBefore = this.getSelectedGeometry();
+    const { picks } = event;
+
+    this._geometryBeforeTranslate =
+      picks.length && selectedFeatureIndexes[0] === picks[0].index ? geometryBefore : null;
+
+    if (selectedFeatureIndexes.length !== 1 || !geometryBefore) {
+      console.warn('translate only supported for single feature selection'); // eslint-disable-line no-console,no-undef
+    }
+
+    return null;
+  }
+
+  handleStopDragging(event: StopDraggingEvent): ?EditAction {
+    let editAction: ?EditAction = null;
+
+    const selectedFeatureIndexes = this.getSelectedFeatureIndexes();
+    if (
+      event.pointerDownGroundCoords &&
+      this._geometryBeforeTranslate &&
+      selectedFeatureIndexes.length === 1
+    ) {
+      // Translate the geometry
+      editAction = this.getEditAction(event.pointerDownGroundCoords, event.groundCoords);
+      if (editAction) {
+        editAction.editType = 'translated';
+      }
+    }
+
+    return editAction;
+  }
+
+  getEditAction(startDragPoint: Position, currentPoint: Position): ?EditAction {
+    if (!this._geometryBeforeTranslate) {
+      return null;
+    }
+    const p1 = point(startDragPoint);
+    const p2 = point(currentPoint);
+
+    const distanceMoved = turfDistance(p1, p2);
+    const direction = turfBearing(p1, p2);
+
+    const movedFeature = turfTransformTranslate(
+      this._geometryBeforeTranslate,
+      distanceMoved,
+      direction
+    );
+    const featureIndex = this.getSelectedFeatureIndexes()[0];
+    const updatedData = this.getImmutableFeatureCollection()
+      .replaceGeometry(featureIndex, movedFeature)
+      .getObject();
+
+    return {
+      updatedData,
+      editType: 'translating',
+      featureIndex,
+      positionIndexes: null,
+      position: null
+    };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,6 +1069,15 @@
     "@turf/helpers" "6.x"
     "@turf/invariant" "6.x"
     martinez-polygon-clipping "^0.4.3"
+"@turf/transform-translate@>=4.0.0":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/transform-translate/-/transform-translate-5.1.5.tgz#530a257fb1dc7268dadcab34e67901eb2a3dec63"
+  dependencies:
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+    "@turf/rhumb-destination" "^5.1.5"
 
 abab@^1.0.3, abab@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This should go after #101 

Adding the new "translate" mode on top of ModeHandler refactor
![nebula-translate-mode-v2](https://user-images.githubusercontent.com/1399914/46688611-6d049400-cc1b-11e8-8b54-50de1b3174b6.gif)
.
Scenario: Select mode as "translate" -> Select any feature -> mouse click + hold on feature and drag to move to desired location. 