### PR TITLE
Ability to duplicate a feature(extend translate mode)

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -139,6 +139,8 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `translated`: A feature finished translating (e.g. user finished dragging).
 
+  * `duplicateFeature`: A feature is duplicated (when user drag the selected feature).
+
 * `featureIndex` (Number): The index of the edited/added feature.
 
 * `positionIndexes` (Array): An array of numbers representing the indexes of the edited position within the features' `coordinates` array

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -139,8 +139,6 @@ The `onEdit` event is the core event provided by this layer and must be handled 
 
   * `translated`: A feature finished translating (e.g. user finished dragging).
 
-  * `duplicateFeature`: A feature is duplicated (when user drag the selected feature).
-
 * `featureIndex` (Number): The index of the edited/added feature.
 
 * `positionIndexes` (Array): An array of numbers representing the indexes of the edited position within the features' `coordinates` array

--- a/docs/api-reference/mode-handlers/overview.md
+++ b/docs/api-reference/mode-handlers/overview.md
@@ -45,7 +45,7 @@ _Note: currently only supports single selection_
 * Mode name: `duplicate`
 
 User can duplicate and translate a feature by clicking selected feature and dragging anywhere on the screen.
-This mode is extended on TranslatedHandler.
+This mode is extended on TranslateHandler.
 
 _Note: currently only supports single selection_
 

--- a/docs/api-reference/mode-handlers/overview.md
+++ b/docs/api-reference/mode-handlers/overview.md
@@ -40,6 +40,15 @@ User can translate a feature by clicking selected feature and dragging anywhere 
 
 _Note: currently only supports single selection_
 
+## [DuplicateHandler](https://github.com/uber/nebula.gl/blob/master/modules/core/src/lib/mode-handlers/duplicate-handler.js)
+
+* Mode name: `duplicate`
+
+User can duplicate and translate a feature by clicking selected feature and dragging anywhere on the screen.
+This mode is extended on TranslatedHandler.
+
+_Note: currently only supports single selection_
+
 ## [DrawPointHandler](https://github.com/uber/nebula.gl/blob/master/modules/core/src/lib/mode-handlers/draw-point-handler.js)
 
 * Mode name: `drawPoint`

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -307,7 +307,7 @@ export default class Example extends Component<
           // reject the edit
           return;
         }
-        if (editType === 'addFeature') {
+        if (editType === 'addFeature' && mode !== 'duplicate') {
           // Add the new feature to the selection
           updatedSelectedFeatureIndexes = [...this.state.selectedFeatureIndexes, featureIndex];
         }

--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -198,6 +198,7 @@ export default class Example extends Component<
               <option value="view">view</option>
               <option value="modify">modify</option>
               <option value="translate">translate</option>
+              <option value="duplicate">duplicate</option>
               <option value="rotate">rotate</option>
               <option value="scale">scale</option>
               <option value="drawPoint">drawPoint</option>
@@ -297,7 +298,7 @@ export default class Example extends Component<
       // Editing callbacks
       onEdit: ({ updatedData, editType, featureIndex, positionIndexes, position }) => {
         let updatedSelectedFeatureIndexes = this.state.selectedFeatureIndexes;
-        if (editType !== 'movePosition' && editType !== 'rotating') {
+        if (!['movePosition', 'rotating', 'translating', 'scaling'].includes(editType)) {
           // Don't log moves since they're really chatty
           // eslint-disable-next-line
           console.log('onEdit', editType, featureIndex, positionIndexes, position);

--- a/modules/core/src/lib/layers/editable-geojson-layer.js
+++ b/modules/core/src/lib/layers/editable-geojson-layer.js
@@ -6,6 +6,7 @@ import { ModeHandler } from '../mode-handlers/mode-handler.js';
 import { ViewHandler } from '../mode-handlers/view-handler.js';
 import { ModifyHandler } from '../mode-handlers/modify-handler.js';
 import { TranslateHandler } from '../mode-handlers/translate-handler.js';
+import { DuplicateHandler } from '../mode-handlers/duplicate-handler';
 import { RotateHandler } from '../mode-handlers/rotate-handler.js';
 import { ScaleHandler } from '../mode-handlers/scale-handler.js';
 import { DrawPointHandler } from '../mode-handlers/draw-point-handler.js';
@@ -104,6 +105,7 @@ const defaultProps = {
     modify: new ModifyHandler(),
     rotate: new RotateHandler(),
     translate: new TranslateHandler(),
+    duplicate: new DuplicateHandler(),
     scale: new ScaleHandler(),
     drawPoint: new DrawPointHandler(),
     drawLineString: new DrawLineStringHandler(),

--- a/modules/core/src/lib/mode-handlers/duplicate-handler.js
+++ b/modules/core/src/lib/mode-handlers/duplicate-handler.js
@@ -1,0 +1,22 @@
+// @flow
+
+import type { StartDraggingEvent } from '../event-types.js';
+import type { EditAction } from './mode-handler.js';
+import { TranslateHandler } from './translate-handler';
+
+export class DuplicateHandler extends TranslateHandler {
+  handleStartDragging(event: StartDraggingEvent): ?EditAction {
+    const selectedFeatureIndexes = this.getSelectedFeatureIndexes();
+    const geometryBefore = this.getSelectedGeometry();
+
+    if (selectedFeatureIndexes.length !== 1 || !geometryBefore) {
+      console.warn('duplicate only supported for single feature selection'); // eslint-disable-line no-console,no-undef
+    } else if (this._isTranslatable) {
+      this._geometryBeforeTranslate = geometryBefore;
+    }
+
+    return this._geometryBeforeTranslate
+      ? { ...this.getAddFeatureAction(this._geometryBeforeTranslate), editType: 'duplicateFeature' }
+      : null;
+  }
+}

--- a/modules/core/src/lib/mode-handlers/duplicate-handler.js
+++ b/modules/core/src/lib/mode-handlers/duplicate-handler.js
@@ -16,7 +16,14 @@ export class DuplicateHandler extends TranslateHandler {
     }
 
     return this._geometryBeforeTranslate
-      ? { ...this.getAddFeatureAction(this._geometryBeforeTranslate), editType: 'duplicateFeature' }
+      ? this.getAddFeatureAction(this._geometryBeforeTranslate)
       : null;
+  }
+
+  getCursor({ isDragging }: { isDragging: boolean }): string {
+    if (this._isTranslatable) {
+      return 'copy';
+    }
+    return isDragging ? 'grabbing' : 'grab';
   }
 }

--- a/modules/core/src/lib/mode-handlers/scale-handler.js
+++ b/modules/core/src/lib/mode-handlers/scale-handler.js
@@ -57,7 +57,7 @@ export class ScaleHandler extends ModeHandler {
     let editAction: ?EditAction = null;
 
     if (this._geometryBeingScaled) {
-      // Sclae the geometry
+      // Scale the geometry
       editAction = this.getScaleAction(event.pointerDownGroundCoords, event.groundCoords, 'scaled');
       this._geometryBeingScaled = null;
     }


### PR DESCRIPTION
Scenario: Select mode as "duplicate" -> Select any feature -> mouse click + hold on feature and drag to move to desired location.

-- Duplicate mode is extended with TranslateHandler.
-- Addressed @supersonicclay comments from #104 

![nebula-duplicate](https://user-images.githubusercontent.com/1399914/46823971-3eb6be00-cdad-11e8-980f-3a085e81a142.gif)
