### PR TITLE
Feature/barebones configurable composite layer

### DIFF
--- a/examples/deck/example.js
+++ b/examples/deck/example.js
@@ -11,6 +11,8 @@ import { EditableGeoJsonLayer } from 'nebula.gl';
 import sampleGeoJson from '../data/sample-geojson.json';
 
 import iconSheet from '../data/edit-handles.png';
+import ScatterplotEditHandleLayer from '../../modules/core/src/lib/layers/scatterplot-edit-handle-layer.js';
+import IconEditHandleLayer from '../../modules/core/src/lib/layers/icon-edit-handle-layer.js';
 
 const initialViewport = {
   bearing: 0,
@@ -289,7 +291,7 @@ export default class Example extends Component<
   }
 
   render() {
-    const { testFeatures, selectedFeatureIndexes, mode, modeConfig, drawAtFront } = this.state;
+    const { testFeatures, selectedFeatureIndexes, mode, modeConfig } = this.state;
 
     const viewport = {
       ...this.state.viewport,
@@ -305,7 +307,44 @@ export default class Example extends Component<
       modeConfig,
       fp64: true,
       autoHighlight: true,
-      drawAtFront,
+
+      // Can customize editing points prop
+      layerOverrides: {
+        ['point-edit-handles']: {
+          Layer: ScatterplotEditHandleLayer,
+          props: {
+            fp64: true,
+            getColor: handle =>
+              handle.type === 'existing' ? [0xff, 0x80, 0x00, 0xff] : [0x0, 0x0, 0x0, 0x80],
+            radiusScale: 2
+          }
+        },
+        ['icon-edit-handles']: {
+          Layer: IconEditHandleLayer,
+          props: {
+            iconAtlas: iconSheet,
+            iconMapping: {
+              intermediate: {
+                x: 0,
+                y: 0,
+                width: 58,
+                height: 58,
+                mask: false
+              },
+              existing: {
+                x: 58,
+                y: 0,
+                width: 58,
+                height: 58,
+                mask: false
+              }
+            },
+            getColor: handle =>
+              handle.type === 'existing' ? [0xff, 0x80, 0x00, 0xff] : [0x0, 0x0, 0x0, 0x80],
+            getSize: 40
+          }
+        }
+      },
 
       // Editing callbacks
       onEdit: ({ updatedData, editType, featureIndex, positionIndexes, position }) => {
@@ -331,27 +370,6 @@ export default class Example extends Component<
 
       // test using icons for edit handles
       editHandleType: this.state.editHandleType,
-      editHandleIconAtlas: iconSheet,
-      editHandleIconMapping: {
-        intermediate: {
-          x: 0,
-          y: 0,
-          width: 58,
-          height: 58,
-          mask: false
-        },
-        existing: {
-          x: 58,
-          y: 0,
-          width: 58,
-          height: 58,
-          mask: false
-        }
-      },
-      getEditHandleIcon: d => d.type,
-      getEditHandleIconSize: 40,
-      getEditHandleIconColor: handle =>
-        handle.type === 'existing' ? [0xff, 0x80, 0x00, 0xff] : [0x0, 0x0, 0x0, 0x80],
 
       // Specify the same GeoJsonLayer props
       lineWidthMinPixels: 2,
@@ -365,11 +383,6 @@ export default class Example extends Component<
       getLineColor: (feature, isSelected) => {
         return isSelected ? [0x00, 0x20, 0x90, 0xff] : [0x20, 0x20, 0x20, 0xff];
       },
-
-      // Can customize editing points props
-      getEditHandlePointColor: handle =>
-        handle.type === 'existing' ? [0xff, 0x80, 0x00, 0xff] : [0x0, 0x0, 0x0, 0x80],
-      editHandlePointRadiusScale: 2,
 
       // customize tentative feature style
       getTentativeLineDashArray: () => [7, 4],

--- a/modules/core/src/lib/layers/configurable-composite-layer.js
+++ b/modules/core/src/lib/layers/configurable-composite-layer.js
@@ -1,0 +1,75 @@
+import { CompositeLayer } from 'deck.gl';
+
+export default class ConfigurableCompositeLayer extends CompositeLayer {
+  _renderLayers() {
+    let { subLayers } = this.internalState;
+    if (subLayers && !this.needsUpdate()) {
+      // log.log(3, `Composite layer reused subLayers ${this}`, this.internalState.subLayers)();
+    } else {
+      subLayers = this.renderLayers();
+      subLayers = this.handleOverrides(subLayers);
+      // Flatten the returned array, removing any null, undefined or false
+      // this allows layers to render sublayers conditionally
+      // (see CompositeLayer.renderLayers docs)
+      subLayers = flatten(subLayers, { filter: Boolean });
+      this.internalState.subLayers = subLayers;
+      // log.log(2, `Composite layer rendered new subLayers ${this}`, subLayers)();
+    }
+
+    // populate reference to parent layer (this layer)
+    // NOTE: needs to be done even when reusing layers as the parent may have changed
+    for (const layer of subLayers) {
+      layer.parent = this;
+    }
+  }
+
+  // if overrides exist, matches sublayers to override and creates a new layer
+  // otherwise returns existing layer
+  handleOverrides(subLayers) {
+    const { layerOverrides } = this.props;
+    if (!layerOverrides) {
+      return subLayers;
+    }
+    return subLayers.map(subLayer => {
+      const subLayerId = subLayer.id.slice(this.props.id.length + 1);
+
+      if (layerOverrides.hasOwnProperty(subLayerId)) {
+        const override = layerOverrides[subLayerId];
+        return new override.Layer(
+          this.getSubLayerProps({
+            ...override.Layer.defaultProps,
+            id: subLayer.id,
+            data: subLayer.props.data,
+            ...override.props
+          })
+        );
+      }
+      // no override
+      return subLayer;
+    });
+  }
+}
+
+/* deck.gl util methods */
+function flatten(array, { filter = () => true, map = x => x, result = [] } = {}) {
+  // Wrap single object in array
+  if (!Array.isArray(array)) {
+    return filter(array) ? [map(array)] : [];
+  }
+  // Deep flatten and filter the array
+  return flattenArray(array, filter, map, result);
+}
+
+// Deep flattens an array. Helper to `flatten`, see its parameters
+function flattenArray(array, filter, map, result) {
+  let index = -1;
+  while (++index < array.length) {
+    const value = array[index];
+    if (Array.isArray(value)) {
+      flattenArray(value, filter, map, result);
+    } else if (filter(value)) {
+      result.push(map(value));
+    }
+  }
+  return result;
+}

--- a/modules/core/src/lib/layers/editable-layer.js
+++ b/modules/core/src/lib/layers/editable-layer.js
@@ -1,7 +1,6 @@
 // @flow
 /* eslint-env browser */
 
-import { CompositeLayer } from 'deck.gl';
 import type {
   ClickEvent,
   StartDraggingEvent,
@@ -10,10 +9,12 @@ import type {
   DoubleClickEvent
 } from '../event-types.js';
 
+import ConfigurableCompositeLayer from './configurable-composite-layer';
+
 // Minimum number of pixels the pointer must move from the original pointer down to be considered dragging
 const MINIMUM_POINTER_MOVE_THRESHOLD_PIXELS = 7;
 
-export default class EditableLayer extends CompositeLayer {
+export default class EditableLayer extends ConfigurableCompositeLayer {
   // Overridable interaction event handlers
   onClick(event: ClickEvent) {
     // default implementation - do nothing

--- a/modules/core/src/lib/layers/icon-edit-handle-layer.js
+++ b/modules/core/src/lib/layers/icon-edit-handle-layer.js
@@ -1,0 +1,31 @@
+// @flow
+import { IconLayer } from 'deck.gl';
+
+const DEFAULT_EDITING_EXISTING_POINT_COLOR = [0xc0, 0x0, 0x0, 0xff];
+const DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR = [0x0, 0x0, 0x0, 0x80];
+
+const defaultProps = {
+  iconAtlas: null,
+  iconMapping: null,
+  sizeScale: 1,
+  getIcon: handle => handle.type,
+  getSize: 10,
+  getColor: handle =>
+    handle.type === 'existing'
+      ? DEFAULT_EDITING_EXISTING_POINT_COLOR
+      : DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR,
+  getAngle: 0,
+  getPosition: d => d.position,
+  parameters: {}
+};
+
+export default class IconEditHandleLayer extends IconLayer {
+  constructor(props) {
+    super({
+      ...defaultProps,
+      ...props
+    });
+  }
+}
+
+IconEditHandleLayer.defaultProps = defaultProps;

--- a/modules/core/src/lib/layers/icon-edit-handle-layer.js
+++ b/modules/core/src/lib/layers/icon-edit-handle-layer.js
@@ -20,7 +20,7 @@ const defaultProps = {
 };
 
 export default class IconEditHandleLayer extends IconLayer {
-  constructor(props) {
+  constructor(props: Object) {
     super({
       ...defaultProps,
       ...props

--- a/modules/core/src/lib/layers/scatterplot-edit-handle-layer.js
+++ b/modules/core/src/lib/layers/scatterplot-edit-handle-layer.js
@@ -19,7 +19,7 @@ const defaultProps = {
 };
 
 export default class ScatterplotEditHandleLayer extends ScatterplotLayer {
-  constructor(props) {
+  constructor(props: Object) {
     super({
       ...defaultProps,
       ...props

--- a/modules/core/src/lib/layers/scatterplot-edit-handle-layer.js
+++ b/modules/core/src/lib/layers/scatterplot-edit-handle-layer.js
@@ -1,0 +1,30 @@
+// @flow
+import { ScatterplotLayer } from 'deck.gl';
+
+const DEFAULT_EDITING_EXISTING_POINT_COLOR = [0xc0, 0x0, 0x0, 0xff];
+const DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR = [0x0, 0x0, 0x0, 0x80];
+
+const defaultProps = {
+  radiusScale: 1,
+  outline: false,
+  strokeWidth: 1,
+  radiusMinPixels: 4,
+  radiusMaxPixels: 8,
+  getRadius: handle => (handle.type === 'existing' ? 5 : 3),
+  getColor: handle =>
+    handle.type === 'existing'
+      ? DEFAULT_EDITING_EXISTING_POINT_COLOR
+      : DEFAULT_EDITING_INTERMEDIATE_POINT_COLOR,
+  parameters: {}
+};
+
+export default class ScatterplotEditHandleLayer extends ScatterplotLayer {
+  constructor(props) {
+    super({
+      ...defaultProps,
+      ...props
+    });
+  }
+}
+
+ScatterplotEditHandleLayer.defaultProps = defaultProps;


### PR DESCRIPTION
Hi, this is a more barebones version of [Matt Rice's PR](https://github.com/uber/nebula.gl/pull/46/).

I removed all the accessor wrapping stuff, since speaking with @supersonicclay revealed that there is really no need for an explicit context (e.g. isSelected, etc.) as the accessors will be defined in scope where they have access to all the application state needed anyway.

I did make it flexible enough so that both individual props or entire layers could be overridden.

Longer term, I think the functionality is a better fit in deck.gl as per @ibgreen's RFC and I am happy to take ownership of that. In the short term, I am hoping to to merge this since it enables so many of the polyline styling requirements in [our internal project] (and we are currently dependent on a local tarball of nebula containing this very change).