### PR TITLE
Issue 157. Pass Nebula childrens to Deck.

### DIFF
--- a/modules/react/src/lib/nebula-react.js
+++ b/modules/react/src/lib/nebula-react.js
@@ -126,8 +126,9 @@ export default class NebulaReact extends Component<Props> {
           viewState={viewport}
           layers={this.nebula.getRenderedLayers()}
           {...extraDeckProps}
-        />
-        {children}
+        >
+          {children}
+        </DeckGL>
       </div>
     );
   }

--- a/modules/react/src/test/overlays/__snapshots__/html-tooltip-overlay.test.js.snap
+++ b/modules/react/src/test/overlays/__snapshots__/html-tooltip-overlay.test.js.snap
@@ -27,15 +27,5 @@ exports[`test HtmlTooltipOverlay no items shown 1`] = `
       }
     />
   </div>
-  <div
-    style={
-      Object {
-        "height": "100%",
-        "pointerEvents": "none",
-        "position": "absolute",
-        "width": "100%",
-      }
-    }
-  />
 </div>
 `;


### PR DESCRIPTION
https://github.com/uber/nebula.gl/issues/157

StaticMap does not get viewState properties if it is child of Nebula react component.
Fix nebula to pass childrens to DeckGL as is 