### PR TITLE
Add support to SnappableHandler to pick from other layers

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -71,6 +71,10 @@ The `mode` property dictates which `ModeHandler` from the `modeHandlers` prop wi
 
 An arbitraty object used to further configure the current `ModeHandler`.
 
+Snapping-related `modeConfig` properties:
+* `enableSnapping` (Boolean, Optional) - Enables snapping for mode handlers that support snapping such as translate mode.
+* `snapPixels` (Number, Optional) - The pixel distance threshold between two features at which snapping occurs.
+* `layerIdsToSnapTo` (String[], Optional) - If there are features in other layers that you would want to interact with features of this `EditableGeoJsonLayer` with regards to feature snapping, you will need to specify the ids of those other layers in this `modeConfig` property.
 #### `modeHandlers` (Object, optional)
 
 * Default: see [mode handlers overview](../mode-handlers/overview.md)

--- a/modules/layers/src/layers/editable-geojson-layer.js
+++ b/modules/layers/src/layers/editable-geojson-layer.js
@@ -262,6 +262,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       modeHandler.setModeConfig(props.modeConfig);
       modeHandler.setSelectedFeatureIndexes(props.selectedFeatureIndexes);
       modeHandler.setDeckGlContext(this.context);
+      modeHandler.setLayerId(props.id);
       this.updateTentativeFeature();
       this.updateEditHandles();
     }

--- a/modules/layers/src/mode-handlers/mode-handler.js
+++ b/modules/layers/src/mode-handlers/mode-handler.js
@@ -38,6 +38,7 @@ export class ModeHandler {
   _selectedFeatureIndexes: number[] = [];
   _clickSequence: Position[] = [];
   _context: Object;
+  _layerId: string;
 
   constructor(featureCollection?: FeatureCollection) {
     if (featureCollection) {
@@ -111,6 +112,10 @@ export class ModeHandler {
 
   setDeckGlContext(context: Object) {
     this._context = context;
+  }
+
+  setLayerId(layerId: string) {
+    this._layerId = layerId;
   }
 
   getClickSequence(): Position[] {

--- a/modules/layers/src/mode-handlers/snappable-handler.js
+++ b/modules/layers/src/mode-handlers/snappable-handler.js
@@ -14,17 +14,10 @@ export class SnappableHandler extends ModeHandler {
   _editHandlePicks: ?HandlePicks;
   _startDragSnapHandlePosition: Position;
   _isSnapped: boolean;
-  pickFromOtherLayerIds: ?(string[]);
-  appendPicksFromOtherLayers: ?boolean;
 
-  constructor(
-    handler: ModeHandler,
-    options: { pickFromOtherLayerIds?: string[], appendPicksFromOtherLayers?: boolean } = {}
-  ) {
+  constructor(handler: ModeHandler) {
     super();
     this._handler = handler;
-    this.pickFromOtherLayerIds = options.pickFromOtherLayerIds;
-    this.appendPicksFromOtherLayers = options.appendPicksFromOtherLayers;
   }
 
   setFeatureCollection(featureCollection: FeatureCollection): void {
@@ -116,16 +109,18 @@ export class SnappableHandler extends ModeHandler {
   // method will simply return the features from this._handler
   _getFeaturesFromRelevantLayer(): any[] {
     let features = [];
-    if (this.pickFromOtherLayerIds) {
+    const { pickFromOtherLayerIds, appendPicksFromOtherLayers } = this._modeConfig || {};
+
+    if (pickFromOtherLayerIds) {
       const otherLayersToPickFrom = this._context.layerManager.layers.filter(
-        layer => this.pickFromOtherLayerIds && this.pickFromOtherLayerIds.includes(layer.id)
+        layer => pickFromOtherLayerIds && pickFromOtherLayerIds.includes(layer.id)
       );
 
       features = otherLayersToPickFrom
         .map(otherLayer => otherLayer.props.data)
         .reduce((a, b) => [...a, ...b], []);
 
-      if (!this.appendPicksFromOtherLayers) {
+      if (!appendPicksFromOtherLayers) {
         return features;
       }
     }
@@ -135,10 +130,11 @@ export class SnappableHandler extends ModeHandler {
   _getNonPickedIntermediateHandles(): EditHandle[] {
     const handles = [];
     const features = this._getFeaturesFromRelevantLayer();
+    const { pickFromOtherLayerIds, appendPicksFromOtherLayers } = this._modeConfig || {};
 
     for (let i = 0; i < features.length; i++) {
       const isIndexSelected =
-        this.pickFromOtherLayerIds && !this.appendPicksFromOtherLayers
+        pickFromOtherLayerIds && !appendPicksFromOtherLayers
           ? true
           : !this._handler.getSelectedFeatureIndexes().includes(i) && i < features.length;
 

--- a/modules/layers/src/mode-handlers/snappable-handler.js
+++ b/modules/layers/src/mode-handlers/snappable-handler.js
@@ -103,10 +103,10 @@ export class SnappableHandler extends ModeHandler {
     }
   }
 
-  // If this.pickFromOtherLayerIds is populated, this method will return the features from the
-  // specified layers. Additionally, if this.appendPicksFromOtherLayers is true, the features
-  // from other layers will be appended to the features in this._handler. Otherwise, this
-  // method will simply return the features from this._handler
+  // If pickFromOtherLayerIds is present in modeConfig, this method will return the features
+  // from the specified layers. Additionally, if appendPicksFromOtherLayers is set to true
+  // in modeConfig, the features from other layers will be appended to the features in
+  // this._handler. Otherwise, this method will simply return the features from this._handler.
   _getFeaturesFromRelevantLayer(): any[] {
     let features = [];
     const { pickFromOtherLayerIds, appendPicksFromOtherLayers } = this._modeConfig || {};

--- a/modules/layers/test/lib/mode-handlers/__snapshots__/snappable-handler.test.js.snap
+++ b/modules/layers/test/lib/mode-handlers/__snapshots__/snappable-handler.test.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SnappableHandler - TranslateHandler tests _getEditHandlePicks() - no _modeConfig 1`] = `
+Object {
+  "pickedHandle": Object {
+    "featureIndex": 0,
+    "position": Array [
+      -122.49485401280788,
+      37.987923255302974,
+    ],
+    "positionIndexes": Array [
+      0,
+      0,
+    ],
+    "type": "snap",
+  },
+  "potentialSnapHandle": Object {
+    "featureIndex": 1,
+    "position": Array [
+      -122.37737022011595,
+      37.97528325161274,
+    ],
+    "positionIndexes": Array [
+      0,
+      1,
+    ],
+    "type": "intermediate",
+  },
+}
+`;
+
 exports[`SnappableHandler - TranslateHandler tests _getEditHandlePicks() - no pickedHandle 1`] = `
 Object {
   "potentialSnapHandle": Object {
@@ -46,7 +75,398 @@ Object {
 }
 `;
 
-exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() 1`] = `
+exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayer() - pickFromOtherLayerIds not specified 1`] = `
+Array [
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.49485401280788,
+            37.987923255302974,
+          ],
+          Array [
+            -122.44252582524939,
+            37.987923255302974,
+          ],
+          Array [
+            -122.44252847887157,
+            37.93873205786406,
+          ],
+          Array [
+            -122.49485666643005,
+            37.93873205786406,
+          ],
+          Array [
+            -122.49485401280788,
+            37.987923255302974,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40814940182412,
+            37.97528325161274,
+          ],
+          Array [
+            -122.37737022011595,
+            37.97528325161274,
+          ],
+          Array [
+            -122.37737142575622,
+            37.952934704562644,
+          ],
+          Array [
+            -122.40815060746439,
+            37.952934704562644,
+          ],
+          Array [
+            -122.40814940182412,
+            37.97528325161274,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        -122.28103267622373,
+        37.98843664327903,
+      ],
+      "type": "Point",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40908525092362,
+            37.85902221692065,
+          ],
+          Array [
+            -122.34432261530361,
+            37.85902221692065,
+          ],
+          Array [
+            -122.3442469760231,
+            37.8157115979288,
+          ],
+          Array [
+            -122.40900961164311,
+            37.8157115979288,
+          ],
+          Array [
+            -122.40908525092362,
+            37.85902221692065,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40682264287454,
+            38.13330760982133,
+          ],
+          Array [
+            -122.34143228624993,
+            38.13330760982133,
+          ],
+          Array [
+            -122.34144710122638,
+            38.08906337516829,
+          ],
+          Array [
+            -122.40683745785105,
+            38.08906337516829,
+          ],
+          Array [
+            -122.40682264287454,
+            38.13330760982133,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+]
+`;
+
+exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified 1`] = `
+Array [
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -1,
+            -1,
+          ],
+          Array [
+            1,
+            -1,
+          ],
+          Array [
+            1,
+            1,
+          ],
+          Array [
+            -1,
+            1,
+          ],
+          Array [
+            -1,
+            -1,
+          ],
+        ],
+        Array [
+          Array [
+            -0.5,
+            -0.5,
+          ],
+          Array [
+            -0.5,
+            0.5,
+          ],
+          Array [
+            0.5,
+            0.5,
+          ],
+          Array [
+            0.5,
+            -0.5,
+          ],
+          Array [
+            -0.5,
+            -0.5,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+]
+`;
+
+exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true 1`] = `
+Array [
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.49485401280788,
+            37.987923255302974,
+          ],
+          Array [
+            -122.44252582524939,
+            37.987923255302974,
+          ],
+          Array [
+            -122.44252847887157,
+            37.93873205786406,
+          ],
+          Array [
+            -122.49485666643005,
+            37.93873205786406,
+          ],
+          Array [
+            -122.49485401280788,
+            37.987923255302974,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40814940182412,
+            37.97528325161274,
+          ],
+          Array [
+            -122.37737022011595,
+            37.97528325161274,
+          ],
+          Array [
+            -122.37737142575622,
+            37.952934704562644,
+          ],
+          Array [
+            -122.40815060746439,
+            37.952934704562644,
+          ],
+          Array [
+            -122.40814940182412,
+            37.97528325161274,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        -122.28103267622373,
+        37.98843664327903,
+      ],
+      "type": "Point",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40908525092362,
+            37.85902221692065,
+          ],
+          Array [
+            -122.34432261530361,
+            37.85902221692065,
+          ],
+          Array [
+            -122.3442469760231,
+            37.8157115979288,
+          ],
+          Array [
+            -122.40900961164311,
+            37.8157115979288,
+          ],
+          Array [
+            -122.40908525092362,
+            37.85902221692065,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40682264287454,
+            38.13330760982133,
+          ],
+          Array [
+            -122.34143228624993,
+            38.13330760982133,
+          ],
+          Array [
+            -122.34144710122638,
+            38.08906337516829,
+          ],
+          Array [
+            -122.40683745785105,
+            38.08906337516829,
+          ],
+          Array [
+            -122.40682264287454,
+            38.13330760982133,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -1,
+            -1,
+          ],
+          Array [
+            1,
+            -1,
+          ],
+          Array [
+            1,
+            1,
+          ],
+          Array [
+            -1,
+            1,
+          ],
+          Array [
+            -1,
+            -1,
+          ],
+        ],
+        Array [
+          Array [
+            -0.5,
+            -0.5,
+          ],
+          Array [
+            -0.5,
+            0.5,
+          ],
+          Array [
+            0.5,
+            0.5,
+          ],
+          Array [
+            0.5,
+            -0.5,
+          ],
+          Array [
+            -0.5,
+            -0.5,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+]
+`;
+
+exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - pickFromOtherLayerIds not specified 1`] = `
 Array [
   Object {
     "featureIndex": 0,
@@ -197,6 +617,361 @@ Array [
     ],
     "positionIndexes": Array [
       0,
+      3,
+    ],
+    "type": "intermediate",
+  },
+]
+`;
+
+exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified 1`] = `
+Array [
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -1,
+      -1,
+    ],
+    "positionIndexes": Array [
+      0,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      1,
+      -1,
+    ],
+    "positionIndexes": Array [
+      0,
+      1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      1,
+      1,
+    ],
+    "positionIndexes": Array [
+      0,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -1,
+      1,
+    ],
+    "positionIndexes": Array [
+      0,
+      3,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -0.5,
+      -0.5,
+    ],
+    "positionIndexes": Array [
+      1,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -0.5,
+      0.5,
+    ],
+    "positionIndexes": Array [
+      1,
+      1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      0.5,
+      0.5,
+    ],
+    "positionIndexes": Array [
+      1,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      0.5,
+      -0.5,
+    ],
+    "positionIndexes": Array [
+      1,
+      3,
+    ],
+    "type": "intermediate",
+  },
+]
+`;
+
+exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true 1`] = `
+Array [
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -122.49485401280788,
+      37.987923255302974,
+    ],
+    "positionIndexes": Array [
+      0,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -122.44252582524939,
+      37.987923255302974,
+    ],
+    "positionIndexes": Array [
+      0,
+      1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -122.44252847887157,
+      37.93873205786406,
+    ],
+    "positionIndexes": Array [
+      0,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 0,
+    "position": Array [
+      -122.49485666643005,
+      37.93873205786406,
+    ],
+    "positionIndexes": Array [
+      0,
+      3,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 2,
+    "position": Array [
+      -122.28103267622373,
+      37.98843664327903,
+    ],
+    "positionIndexes": Array [],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 3,
+    "position": Array [
+      -122.40908525092362,
+      37.85902221692065,
+    ],
+    "positionIndexes": Array [
+      0,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 3,
+    "position": Array [
+      -122.34432261530361,
+      37.85902221692065,
+    ],
+    "positionIndexes": Array [
+      0,
+      1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 3,
+    "position": Array [
+      -122.3442469760231,
+      37.8157115979288,
+    ],
+    "positionIndexes": Array [
+      0,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 3,
+    "position": Array [
+      -122.40900961164311,
+      37.8157115979288,
+    ],
+    "positionIndexes": Array [
+      0,
+      3,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.40682264287454,
+      38.13330760982133,
+    ],
+    "positionIndexes": Array [
+      0,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.34143228624993,
+      38.13330760982133,
+    ],
+    "positionIndexes": Array [
+      0,
+      1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.34144710122638,
+      38.08906337516829,
+    ],
+    "positionIndexes": Array [
+      0,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.40683745785105,
+      38.08906337516829,
+    ],
+    "positionIndexes": Array [
+      0,
+      3,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      -1,
+      -1,
+    ],
+    "positionIndexes": Array [
+      0,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      1,
+      -1,
+    ],
+    "positionIndexes": Array [
+      0,
+      1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      1,
+      1,
+    ],
+    "positionIndexes": Array [
+      0,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      -1,
+      1,
+    ],
+    "positionIndexes": Array [
+      0,
+      3,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      -0.5,
+      -0.5,
+    ],
+    "positionIndexes": Array [
+      1,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      -0.5,
+      0.5,
+    ],
+    "positionIndexes": Array [
+      1,
+      1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      0.5,
+      0.5,
+    ],
+    "positionIndexes": Array [
+      1,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 5,
+    "position": Array [
+      0.5,
+      -0.5,
+    ],
+    "positionIndexes": Array [
+      1,
       3,
     ],
     "type": "intermediate",
@@ -841,6 +1616,244 @@ Array [
 `;
 
 exports[`SnappableHandler - TranslateHandler tests handlePointerMove() - positive case 1`] = `
+Array [
+  Object {
+    "editContext": null,
+    "editType": "translating",
+    "featureIndexes": Array [
+      0,
+    ],
+    "featureindexes": Array [
+      2,
+    ],
+    "updatedData": Object {
+      "features": Array [
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              1,
+              2,
+            ],
+            "type": "Point",
+          },
+          "properties": Object {},
+          "type": "Feature",
+        },
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              Array [
+                1,
+                2,
+              ],
+              Array [
+                2,
+                3,
+              ],
+              Array [
+                3,
+                4,
+              ],
+            ],
+            "type": "LineString",
+          },
+          "properties": Object {},
+          "type": "Feature",
+        },
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              Array [
+                Array [
+                  -1,
+                  -1,
+                ],
+                Array [
+                  1,
+                  -1,
+                ],
+                Array [
+                  1,
+                  1,
+                ],
+                Array [
+                  -1,
+                  1,
+                ],
+                Array [
+                  -1,
+                  -1,
+                ],
+              ],
+              Array [
+                Array [
+                  -0.5,
+                  -0.5,
+                ],
+                Array [
+                  -0.5,
+                  0.5,
+                ],
+                Array [
+                  0.5,
+                  0.5,
+                ],
+                Array [
+                  0.5,
+                  -0.5,
+                ],
+                Array [
+                  -0.5,
+                  -0.5,
+                ],
+              ],
+            ],
+            "type": "Polygon",
+          },
+          "properties": Object {},
+          "type": "Feature",
+        },
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              Array [
+                1,
+                2,
+              ],
+              Array [
+                3,
+                4,
+              ],
+            ],
+            "type": "MultiPoint",
+          },
+          "properties": Object {},
+          "type": "Feature",
+        },
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              Array [
+                Array [
+                  1,
+                  2,
+                ],
+                Array [
+                  2,
+                  3,
+                ],
+                Array [
+                  3,
+                  4,
+                ],
+              ],
+              Array [
+                Array [
+                  5,
+                  6,
+                ],
+                Array [
+                  6,
+                  7,
+                ],
+                Array [
+                  7,
+                  8,
+                ],
+              ],
+            ],
+            "type": "MultiLineString",
+          },
+          "properties": Object {},
+          "type": "Feature",
+        },
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              Array [
+                Array [
+                  Array [
+                    -1,
+                    -1,
+                  ],
+                  Array [
+                    1,
+                    -1,
+                  ],
+                  Array [
+                    1,
+                    1,
+                  ],
+                  Array [
+                    -1,
+                    1,
+                  ],
+                  Array [
+                    -1,
+                    -1,
+                  ],
+                ],
+                Array [
+                  Array [
+                    -0.5,
+                    -0.5,
+                  ],
+                  Array [
+                    -0.5,
+                    0.5,
+                  ],
+                  Array [
+                    0.5,
+                    0.5,
+                  ],
+                  Array [
+                    0.5,
+                    -0.5,
+                  ],
+                  Array [
+                    -0.5,
+                    -0.5,
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    2,
+                    -1,
+                  ],
+                  Array [
+                    4,
+                    -1,
+                  ],
+                  Array [
+                    4,
+                    1,
+                  ],
+                  Array [
+                    2,
+                    1,
+                  ],
+                  Array [
+                    2,
+                    -1,
+                  ],
+                ],
+              ],
+            ],
+            "type": "MultiPolygon",
+          },
+          "properties": Object {},
+          "type": "Feature",
+        },
+      ],
+      "type": "FeatureCollection",
+    },
+  },
+]
+`;
+
+exports[`SnappableHandler - TranslateHandler tests handlePointerMove() - this._getEditHandlePicks does not return anything 1`] = `
 Array [
   Object {
     "editContext": null,

--- a/modules/layers/test/lib/mode-handlers/__snapshots__/snappable-handler.test.js.snap
+++ b/modules/layers/test/lib/mode-handlers/__snapshots__/snappable-handler.test.js.snap
@@ -75,7 +75,7 @@ Object {
 }
 `;
 
-exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayer() - pickFromOtherLayerIds not specified 1`] = `
+exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayers() - invalid layerIdsToSnapTo specified 1`] = `
 Array [
   Object {
     "geometry": Object {
@@ -215,53 +215,135 @@ Array [
 ]
 `;
 
-exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified 1`] = `
+exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayers() - layerIdsToSnapTo not specified 1`] = `
 Array [
   Object {
     "geometry": Object {
       "coordinates": Array [
         Array [
           Array [
-            -1,
-            -1,
+            -122.49485401280788,
+            37.987923255302974,
           ],
           Array [
-            1,
-            -1,
+            -122.44252582524939,
+            37.987923255302974,
           ],
           Array [
-            1,
-            1,
+            -122.44252847887157,
+            37.93873205786406,
           ],
           Array [
-            -1,
-            1,
+            -122.49485666643005,
+            37.93873205786406,
           ],
           Array [
-            -1,
-            -1,
+            -122.49485401280788,
+            37.987923255302974,
           ],
         ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
         Array [
           Array [
-            -0.5,
-            -0.5,
+            -122.40814940182412,
+            37.97528325161274,
           ],
           Array [
-            -0.5,
-            0.5,
+            -122.37737022011595,
+            37.97528325161274,
           ],
           Array [
-            0.5,
-            0.5,
+            -122.37737142575622,
+            37.952934704562644,
           ],
           Array [
-            0.5,
-            -0.5,
+            -122.40815060746439,
+            37.952934704562644,
           ],
           Array [
-            -0.5,
-            -0.5,
+            -122.40814940182412,
+            37.97528325161274,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        -122.28103267622373,
+        37.98843664327903,
+      ],
+      "type": "Point",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40908525092362,
+            37.85902221692065,
+          ],
+          Array [
+            -122.34432261530361,
+            37.85902221692065,
+          ],
+          Array [
+            -122.3442469760231,
+            37.8157115979288,
+          ],
+          Array [
+            -122.40900961164311,
+            37.8157115979288,
+          ],
+          Array [
+            -122.40908525092362,
+            37.85902221692065,
+          ],
+        ],
+      ],
+      "type": "Polygon",
+    },
+    "properties": Object {},
+    "type": "Feature",
+  },
+  Object {
+    "geometry": Object {
+      "coordinates": Array [
+        Array [
+          Array [
+            -122.40682264287454,
+            38.13330760982133,
+          ],
+          Array [
+            -122.34143228624993,
+            38.13330760982133,
+          ],
+          Array [
+            -122.34144710122638,
+            38.08906337516829,
+          ],
+          Array [
+            -122.40683745785105,
+            38.08906337516829,
+          ],
+          Array [
+            -122.40682264287454,
+            38.13330760982133,
           ],
         ],
       ],
@@ -273,7 +355,7 @@ Array [
 ]
 `;
 
-exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true 1`] = `
+exports[`SnappableHandler - TranslateHandler tests _getFeaturesFromRelevantLayers() - valid layerIdsToSnapTo specified 1`] = `
 Array [
   Object {
     "geometry": Object {
@@ -466,7 +548,7 @@ Array [
 ]
 `;
 
-exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - pickFromOtherLayerIds not specified 1`] = `
+exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - invalid layerIdsToSnapTo specified 1`] = `
 Array [
   Object {
     "featureIndex": 0,
@@ -624,13 +706,13 @@ Array [
 ]
 `;
 
-exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified 1`] = `
+exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - layerIdsToSnapTo not specified 1`] = `
 Array [
   Object {
     "featureIndex": 0,
     "position": Array [
-      -1,
-      -1,
+      -122.49485401280788,
+      37.987923255302974,
     ],
     "positionIndexes": Array [
       0,
@@ -641,8 +723,8 @@ Array [
   Object {
     "featureIndex": 0,
     "position": Array [
-      1,
-      -1,
+      -122.44252582524939,
+      37.987923255302974,
     ],
     "positionIndexes": Array [
       0,
@@ -653,8 +735,8 @@ Array [
   Object {
     "featureIndex": 0,
     "position": Array [
-      1,
-      1,
+      -122.44252847887157,
+      37.93873205786406,
     ],
     "positionIndexes": Array [
       0,
@@ -665,8 +747,8 @@ Array [
   Object {
     "featureIndex": 0,
     "position": Array [
-      -1,
-      1,
+      -122.49485666643005,
+      37.93873205786406,
     ],
     "positionIndexes": Array [
       0,
@@ -675,49 +757,106 @@ Array [
     "type": "intermediate",
   },
   Object {
-    "featureIndex": 0,
+    "featureIndex": 2,
     "position": Array [
-      -0.5,
-      -0.5,
+      -122.28103267622373,
+      37.98843664327903,
+    ],
+    "positionIndexes": Array [],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 3,
+    "position": Array [
+      -122.40908525092362,
+      37.85902221692065,
     ],
     "positionIndexes": Array [
-      1,
+      0,
       0,
     ],
     "type": "intermediate",
   },
   Object {
-    "featureIndex": 0,
+    "featureIndex": 3,
     "position": Array [
-      -0.5,
-      0.5,
+      -122.34432261530361,
+      37.85902221692065,
     ],
     "positionIndexes": Array [
-      1,
+      0,
       1,
     ],
     "type": "intermediate",
   },
   Object {
-    "featureIndex": 0,
+    "featureIndex": 3,
     "position": Array [
-      0.5,
-      0.5,
+      -122.3442469760231,
+      37.8157115979288,
     ],
     "positionIndexes": Array [
-      1,
+      0,
       2,
     ],
     "type": "intermediate",
   },
   Object {
-    "featureIndex": 0,
+    "featureIndex": 3,
     "position": Array [
-      0.5,
-      -0.5,
+      -122.40900961164311,
+      37.8157115979288,
     ],
     "positionIndexes": Array [
+      0,
+      3,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.40682264287454,
+      38.13330760982133,
+    ],
+    "positionIndexes": Array [
+      0,
+      0,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.34143228624993,
+      38.13330760982133,
+    ],
+    "positionIndexes": Array [
+      0,
       1,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.34144710122638,
+      38.08906337516829,
+    ],
+    "positionIndexes": Array [
+      0,
+      2,
+    ],
+    "type": "intermediate",
+  },
+  Object {
+    "featureIndex": 4,
+    "position": Array [
+      -122.40683745785105,
+      38.08906337516829,
+    ],
+    "positionIndexes": Array [
+      0,
       3,
     ],
     "type": "intermediate",
@@ -725,7 +864,7 @@ Array [
 ]
 `;
 
-exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true 1`] = `
+exports[`SnappableHandler - TranslateHandler tests _getNonPickedIntermediateHandles() - valid layerIdsToSnapTo specified 1`] = `
 Array [
   Object {
     "featureIndex": 0,

--- a/modules/layers/test/lib/mode-handlers/snappable-handler.test.js
+++ b/modules/layers/test/lib/mode-handlers/snappable-handler.test.js
@@ -8,7 +8,8 @@ import {
   createPointerMoveEvent,
   featuresForSnappingTests,
   mockPickedHandle,
-  mockNonPickedHandle
+  mockNonPickedHandle,
+  createPolygonFeature
 } from '../test-utils.js';
 
 const mockTranslateEditAction = updatedData => ({
@@ -21,13 +22,19 @@ const mockTranslateEditAction = updatedData => ({
 function mockFeatureCollectionState(features: any) {
   const translateHandler = new TranslateHandler(features);
   const snappableHandler = new SnappableHandler(translateHandler);
+  const otherLayerToPickFrom = {
+    id: 'other-layer-test',
+    props: {
+      data: [createPolygonFeature()]
+    }
+  };
   const context = {
     viewport: {
       project: coords => coords
     },
     layerManager: {
       pickObject: () => [{ object: mockNonPickedHandle }],
-      layers: [{ id: '-point-edit-handles' }]
+      layers: [{ id: '-point-edit-handles' }, otherLayerToPickFrom]
     }
   };
 
@@ -110,6 +117,18 @@ describe('SnappableHandler - TranslateHandler tests', () => {
     expect(snappedMouseEvent).toEqual(expectedSnappedMouseEvent);
   });
 
+  test('_getEditHandleLayerId() - positive case', () => {
+    expect(snappableHandler._getEditHandleLayerId()).toEqual('-point-edit-handles');
+  });
+
+  test('_getEditHandleLayerId() - no matching layer', () => {
+    const originalLayers = snappableHandler._context.layerManager.layers;
+    const filteredOutLayers = originalLayers.filter(layer => !layer.id.endsWith('-edit-handles'));
+    snappableHandler._context.layerManager.layers = filteredOutLayers;
+
+    expect(snappableHandler._getEditHandleLayerId()).toEqual('');
+  });
+
   test('_getEditHandlePicks() - positive case', () => {
     snappableHandler.setModeConfig({ snapPixels: 5 });
     const mouseMoveEvent = createPointerMoveEvent([100, 100], []);
@@ -137,6 +156,25 @@ describe('SnappableHandler - TranslateHandler tests', () => {
 
     const picks = snappableHandler._getEditHandlePicks(mouseMoveEvent);
     expect(picks.pickedHandle).not.toBeDefined();
+    expect(picks.potentialSnapHandle).toBeDefined();
+    if (picks.potentialSnapHandle) {
+      expect(picks.potentialSnapHandle.type).toEqual('intermediate');
+    }
+    expect(picks).toMatchSnapshot();
+  });
+
+  test('_getEditHandlePicks() - no _modeConfig', () => {
+    const mouseMoveEvent = createPointerMoveEvent([100, 100], []);
+    mouseMoveEvent.screenCoords = [1, 1];
+    mouseMoveEvent.pointerDownPicks = [
+      { index: 0, isEditingHandle: true, object: mockPickedHandle }
+    ];
+
+    const picks = snappableHandler._getEditHandlePicks(mouseMoveEvent);
+    expect(picks.pickedHandle).toBeDefined();
+    if (picks.pickedHandle) {
+      expect(picks.pickedHandle.type).toEqual('snap');
+    }
     expect(picks.potentialSnapHandle).toBeDefined();
     if (picks.potentialSnapHandle) {
       expect(picks.potentialSnapHandle.type).toEqual('intermediate');
@@ -193,7 +231,61 @@ describe('SnappableHandler - TranslateHandler tests', () => {
     expect(pickedHandle).toEqual(initialPickedHandle);
   });
 
-  test('_getNonPickedIntermediateHandles()', () => {
+  test('_getFeaturesFromRelevantLayer() - pickFromOtherLayerIds not specified', () => {
+    const features = snappableHandler._getFeaturesFromRelevantLayer();
+    expect(features.length).toEqual(5);
+    expect(features).toMatchSnapshot();
+  });
+
+  test('_getFeaturesFromRelevantLayer() - invalid pickFromOtherLayerIds specified', () => {
+    snappableHandler.pickFromOtherLayerIds = ['invalid-layer-id'];
+    const features = snappableHandler._getFeaturesFromRelevantLayer();
+    expect(features).toEqual([]);
+  });
+
+  test('_getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified', () => {
+    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
+    const features = snappableHandler._getFeaturesFromRelevantLayer();
+    expect(features.length).toEqual(1);
+    expect(features).toMatchSnapshot();
+  });
+
+  test('_getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true', () => {
+    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
+    snappableHandler.appendPicksFromOtherLayers = true;
+    const features = snappableHandler._getFeaturesFromRelevantLayer();
+    expect(features.length).toEqual(6);
+    expect(features).toMatchSnapshot();
+  });
+
+  test('_getNonPickedIntermediateHandles() - pickFromOtherLayerIds not specified', () => {
+    const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
+    const areAllHandleTypesIntermediate = intermediateHandles.every(
+      ({ type }) => type === 'intermediate'
+    );
+    expect(areAllHandleTypesIntermediate).toBeTruthy();
+    expect(intermediateHandles).toMatchSnapshot();
+  });
+
+  test('_getNonPickedIntermediateHandles() - invalid pickFromOtherLayerIds specified', () => {
+    snappableHandler.pickFromOtherLayerIds = ['invalid-layer-id'];
+    const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
+    expect(intermediateHandles).toEqual([]);
+  });
+
+  test('_getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified', () => {
+    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
+    const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
+    const areAllHandleTypesIntermediate = intermediateHandles.every(
+      ({ type }) => type === 'intermediate'
+    );
+    expect(areAllHandleTypesIntermediate).toBeTruthy();
+    expect(intermediateHandles).toMatchSnapshot();
+  });
+
+  test('_getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true', () => {
+    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
+    snappableHandler.appendPicksFromOtherLayers = true;
     const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
     const areAllHandleTypesIntermediate = intermediateHandles.every(
       ({ type }) => type === 'intermediate'
@@ -429,6 +521,37 @@ describe('SnappableHandler - TranslateHandler tests', () => {
 
     expect(snappableHandler._performSnapIfRequired).toBeCalled();
     expect(snappableHandler._performUnsnapIfRequired).toBeCalled();
+    expect(snappableHandler._updatePickedHandlePosition).toBeCalled();
+    expect(snappableHandler._updatePickedHandlePosition.mock.calls[0]).toMatchSnapshot();
+  });
+
+  test('handlePointerMove() - this._getEditHandlePicks does not return anything', () => {
+    snappableHandler.setModeConfig({ enableSnapping: true });
+    snappableHandler._editHandlePicks = {
+      pickedHandle: mockPickedHandle,
+      potentialSnapHandle: mockNonPickedHandle
+    };
+    // $FlowFixMe
+    snappableHandler._performSnapIfRequired = jest.fn();
+    // $FlowFixMe
+    snappableHandler._performUnsnapIfRequired = jest.fn();
+    // $FlowFixMe
+    snappableHandler._updatePickedHandlePosition = jest.fn();
+    const mockedEditActionSummary = {
+      editAction: Object.assign({}, mockTranslateEditAction(createFeatureCollection()), {
+        featureindexes: [2]
+      })
+    };
+    // $FlowFixMe
+    snappableHandler._getEditHandlePicks = jest.fn(v => null);
+    // $FlowFixMe
+    translateHandler.handlePointerMove = jest.fn(v => mockedEditActionSummary);
+    const event = createPointerMoveEvent([20, 20]);
+    const eventSummary = snappableHandler.handlePointerMove(event);
+    expect(eventSummary).toBeDefined();
+
+    expect(snappableHandler._performSnapIfRequired).not.toBeCalled();
+    expect(snappableHandler._performUnsnapIfRequired).not.toBeCalled();
     expect(snappableHandler._updatePickedHandlePosition).toBeCalled();
     expect(snappableHandler._updatePickedHandlePosition.mock.calls[0]).toMatchSnapshot();
   });

--- a/modules/layers/test/lib/mode-handlers/snappable-handler.test.js
+++ b/modules/layers/test/lib/mode-handlers/snappable-handler.test.js
@@ -231,36 +231,27 @@ describe('SnappableHandler - TranslateHandler tests', () => {
     expect(pickedHandle).toEqual(initialPickedHandle);
   });
 
-  test('_getFeaturesFromRelevantLayer() - pickFromOtherLayerIds not specified', () => {
-    const features = snappableHandler._getFeaturesFromRelevantLayer();
+  test('_getFeaturesFromRelevantLayers() - layerIdsToSnapTo not specified', () => {
+    const features = snappableHandler._getFeaturesFromRelevantLayers();
     expect(features.length).toEqual(5);
     expect(features).toMatchSnapshot();
   });
 
-  test('_getFeaturesFromRelevantLayer() - invalid pickFromOtherLayerIds specified', () => {
-    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['invalid-layer-id'] });
-    const features = snappableHandler._getFeaturesFromRelevantLayer();
-    expect(features).toEqual([]);
-  });
-
-  test('_getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified', () => {
-    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['other-layer-test'] });
-    const features = snappableHandler._getFeaturesFromRelevantLayer();
-    expect(features.length).toEqual(1);
+  test('_getFeaturesFromRelevantLayers() - invalid layerIdsToSnapTo specified', () => {
+    snappableHandler.setModeConfig({ layerIdsToSnapTo: ['invalid-layer-id'] });
+    const features = snappableHandler._getFeaturesFromRelevantLayers();
+    expect(features.length).toEqual(5);
     expect(features).toMatchSnapshot();
   });
 
-  test('_getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true', () => {
-    snappableHandler.setModeConfig({
-      pickFromOtherLayerIds: ['other-layer-test'],
-      appendPicksFromOtherLayers: true
-    });
-    const features = snappableHandler._getFeaturesFromRelevantLayer();
+  test('_getFeaturesFromRelevantLayers() - valid layerIdsToSnapTo specified', () => {
+    snappableHandler.setModeConfig({ layerIdsToSnapTo: ['other-layer-test'] });
+    const features = snappableHandler._getFeaturesFromRelevantLayers();
     expect(features.length).toEqual(6);
     expect(features).toMatchSnapshot();
   });
 
-  test('_getNonPickedIntermediateHandles() - pickFromOtherLayerIds not specified', () => {
+  test('_getNonPickedIntermediateHandles() - layerIdsToSnapTo not specified', () => {
     const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
     const areAllHandleTypesIntermediate = intermediateHandles.every(
       ({ type }) => type === 'intermediate'
@@ -269,27 +260,15 @@ describe('SnappableHandler - TranslateHandler tests', () => {
     expect(intermediateHandles).toMatchSnapshot();
   });
 
-  test('_getNonPickedIntermediateHandles() - invalid pickFromOtherLayerIds specified', () => {
-    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['invalid-layer-id'] });
+  test('_getNonPickedIntermediateHandles() - invalid layerIdsToSnapTo specified', () => {
+    snappableHandler.setModeConfig({ layerIdsToSnapTo: ['invalid-layer-id'] });
     const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
-    expect(intermediateHandles).toEqual([]);
-  });
-
-  test('_getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified', () => {
-    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['other-layer-test'] });
-    const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
-    const areAllHandleTypesIntermediate = intermediateHandles.every(
-      ({ type }) => type === 'intermediate'
-    );
-    expect(areAllHandleTypesIntermediate).toBeTruthy();
+    expect(intermediateHandles.length > 0).toBeTruthy();
     expect(intermediateHandles).toMatchSnapshot();
   });
 
-  test('_getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true', () => {
-    snappableHandler.setModeConfig({
-      pickFromOtherLayerIds: ['other-layer-test'],
-      appendPicksFromOtherLayers: true
-    });
+  test('_getNonPickedIntermediateHandles() - valid layerIdsToSnapTo specified', () => {
+    snappableHandler.setModeConfig({ layerIdsToSnapTo: ['other-layer-test'] });
     const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
     const areAllHandleTypesIntermediate = intermediateHandles.every(
       ({ type }) => type === 'intermediate'

--- a/modules/layers/test/lib/mode-handlers/snappable-handler.test.js
+++ b/modules/layers/test/lib/mode-handlers/snappable-handler.test.js
@@ -238,21 +238,23 @@ describe('SnappableHandler - TranslateHandler tests', () => {
   });
 
   test('_getFeaturesFromRelevantLayer() - invalid pickFromOtherLayerIds specified', () => {
-    snappableHandler.pickFromOtherLayerIds = ['invalid-layer-id'];
+    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['invalid-layer-id'] });
     const features = snappableHandler._getFeaturesFromRelevantLayer();
     expect(features).toEqual([]);
   });
 
   test('_getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified', () => {
-    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
+    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['other-layer-test'] });
     const features = snappableHandler._getFeaturesFromRelevantLayer();
     expect(features.length).toEqual(1);
     expect(features).toMatchSnapshot();
   });
 
   test('_getFeaturesFromRelevantLayer() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true', () => {
-    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
-    snappableHandler.appendPicksFromOtherLayers = true;
+    snappableHandler.setModeConfig({
+      pickFromOtherLayerIds: ['other-layer-test'],
+      appendPicksFromOtherLayers: true
+    });
     const features = snappableHandler._getFeaturesFromRelevantLayer();
     expect(features.length).toEqual(6);
     expect(features).toMatchSnapshot();
@@ -268,13 +270,13 @@ describe('SnappableHandler - TranslateHandler tests', () => {
   });
 
   test('_getNonPickedIntermediateHandles() - invalid pickFromOtherLayerIds specified', () => {
-    snappableHandler.pickFromOtherLayerIds = ['invalid-layer-id'];
+    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['invalid-layer-id'] });
     const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
     expect(intermediateHandles).toEqual([]);
   });
 
   test('_getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified', () => {
-    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
+    snappableHandler.setModeConfig({ pickFromOtherLayerIds: ['other-layer-test'] });
     const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
     const areAllHandleTypesIntermediate = intermediateHandles.every(
       ({ type }) => type === 'intermediate'
@@ -284,8 +286,10 @@ describe('SnappableHandler - TranslateHandler tests', () => {
   });
 
   test('_getNonPickedIntermediateHandles() - valid pickFromOtherLayerIds specified with appendPicksFromOtherLayers = true', () => {
-    snappableHandler.pickFromOtherLayerIds = ['other-layer-test'];
-    snappableHandler.appendPicksFromOtherLayers = true;
+    snappableHandler.setModeConfig({
+      pickFromOtherLayerIds: ['other-layer-test'],
+      appendPicksFromOtherLayers: true
+    });
     const intermediateHandles = snappableHandler._getNonPickedIntermediateHandles();
     const areAllHandleTypesIntermediate = intermediateHandles.every(
       ({ type }) => type === 'intermediate'


### PR DESCRIPTION
I introduced one new modeConfig property:
* `layerIdsToSnapTo: ?(string[])`

If `layerIdsToSnapTo` is present, the `SnappableHandler` will look for picks in the specified layers in addition to features in the current `SnappableHandler._handler`. If `layerIdsToSnapTo` isn't defined, the handler will default to picking from the current `SnappableHandler._handler`.

To see this feature in action, paste the following code snippet in the `render()` method (right before the method returns) in the file `examples/deck/example.js`:
```js
    layers.push(
      new EditableGeoJsonLayer({
        id: 'test-layer',
        selectedFeatureIndexes: [],
        fp64: false,
        getFillColor: [255, 0, 0, 255],
        data: [
          {"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-122.3952996456623,37.877279091381524],[-122.34470916032794,37.877279091381524],[-122.34470916032794,37.85118811159345],[-122.3952996456623,37.85118811159345],[-122.3952996456623,37.877279091381524]]]}}
        ]
      })
    );

    layers.push(
      new EditableGeoJsonLayer({
        id: 'test-layer2',
        selectedFeatureIndexes: [],
        fp64: false,
        getFillColor: [0, 255, 0, 255],
        data: [{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-122.51409022077985,37.869217283494564],[-122.55434977639163,37.88652710247724],[-122.56327414956525,37.86102193657733],[-122.54391170517715,37.854042309973],[-122.54390179262947,37.81944995034826],[-122.51973008097127,37.84256451196541],[-122.4808255716967,37.83945728896286],[-122.47966972189454,37.861229451757495],[-122.4797338087995,37.88959953265049],[-122.51969204410665,37.889800617306385],[-122.52789951696104,37.90947991368635],[-122.54375610750321,37.89454288093134],[-122.51409022077985,37.869217283494564]]]}}]
      })
    );
```

and set the `EditableGeoJsonLayer` constructor modeConfig to:
```js
{
  ...modeConfig,
  layerIdsToSnapTo: ['test-layer', 'test-layer2']
}
```

Note that the green and red polygons live in their own separate layers.