### PR TITLE
Exposing ReactMapGl Draw constants: RENDER_TYPE and RENDER_STATE

### DIFF
--- a/modules/react-map-gl-draw/src/index.js
+++ b/modules/react-map-gl-draw/src/index.js
@@ -1,3 +1,7 @@
 // @flow
 export { default as Editor } from './editor';
-export { MODES as EditorModes } from './constants';
+export {
+  MODES as EditorModes,
+  RENDER_TYPE as RenderTypes,
+  RENDER_STATE as RenderStates
+} from './constants';


### PR DESCRIPTION
Exposing the Draw constants allow developers to easily customize drawing style by using existing handle types and states