### PR TITLE
Make dragging features more resilient to lagging feature element

### DIFF
--- a/modules/react-map-gl-draw/src/editor.js
+++ b/modules/react-map-gl-draw/src/editor.js
@@ -344,7 +344,7 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
         startDragPos: { x, y },
         isDragging: true
       });
-    } else if (this._isFeature(elem)) {
+    } else if (this._matchesFeature(elem, this._getSelectedFeature())) {
       this.setState({
         startDragPos: { x, y },
         isDragging: true
@@ -379,7 +379,7 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
         if (vertexIndex >= 0) {
           // dragging vertex
           this._updateFeature(selectedFeature, 'vertex', { vertexIndex, lngLat });
-        } else if (this._matchesFeature(elem, selectedFeature)) {
+        } else {
           // dragging feature
           const dx = x - startDragPos.x;
           const dy = y - startDragPos.y;


### PR DESCRIPTION
#246 resulted in weird dragging behavior when the feature element lags behind the mouse (such as when the map is zoomed out). This fixes the behavior so that you can only initiate a drag on top of the currently selected feature, but `mousemove`s modify the feature regardless of the cursor position.

It is safe to keep the `_matchesFeature` check in `_onPan` as-is, as `panmove` events aren't fired if `stopImmediatePropagation` is called on `panstart`. I also verified that the behavior remains correct for lines/points.

Before:
![drag-fix-before-redux](https://user-images.githubusercontent.com/8008350/60634310-57e01e80-9dc3-11e9-9ed7-edce57a4c12f.gif)

After:
![drag-fix-after-redux](https://user-images.githubusercontent.com/8008350/60634322-62021d00-9dc3-11e9-942b-204f855a61c1.gif)
