### PR TITLE
React-map-gl-draw: propagating onSelect mouse event

### DIFF
--- a/modules/react-map-gl-draw/src/editor.js
+++ b/modules/react-map-gl-draw/src/editor.js
@@ -446,9 +446,7 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
       feature &&
       (this.props.mode === MODES.SELECT_FEATURE || this.props.mode === MODES.EDIT_VERTEX)
     ) {
-      this.props.onSelect({
-        selectedFeatureId: feature.id
-      });
+      this.props.onSelect({ selectedFeatureId: feature.id }, evt);
     }
   };
 
@@ -523,7 +521,7 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
     switch (mode) {
       case MODES.EDIT_VERTEX:
         if (selectedFeature) {
-          this.props.onSelect({ selectedFeatureId: null });
+          this.props.onSelect({ selectedFeatureId: null }, evt);
         }
         break;
 
@@ -547,7 +545,7 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
         if (selectedFeature && selectedFeature.isClosed) {
           // clicked outside
           this._clearCache();
-          this.props.onSelect({ selectedFeatureId: null });
+          this.props.onSelect({ selectedFeatureId: null }, evt);
         } else {
           this._addFeature(mode, { x, y });
         }

--- a/modules/react-map-gl-draw/src/editor.js
+++ b/modules/react-map-gl-draw/src/editor.js
@@ -446,7 +446,10 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
       feature &&
       (this.props.mode === MODES.SELECT_FEATURE || this.props.mode === MODES.EDIT_VERTEX)
     ) {
-      this.props.onSelect({ selectedFeatureId: feature.id }, evt);
+      this.props.onSelect({
+        selectedFeatureId: feature.id,
+        sourceEvent: evt
+      });
     }
   };
 
@@ -521,7 +524,10 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
     switch (mode) {
       case MODES.EDIT_VERTEX:
         if (selectedFeature) {
-          this.props.onSelect({ selectedFeatureId: null }, evt);
+          this.props.onSelect({
+            selectedFeatureId: null,
+            sourceEvent: evt
+          });
         }
         break;
 
@@ -545,7 +551,10 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
         if (selectedFeature && selectedFeature.isClosed) {
           // clicked outside
           this._clearCache();
-          this.props.onSelect({ selectedFeatureId: null }, evt);
+          this.props.onSelect({
+            selectedFeatureId: null,
+            sourceEvent: evt
+          });
         } else {
           this._addFeature(mode, { x, y });
         }


### PR DESCRIPTION
This pull request allows developers to capture the mouse event every time a user selects a feature.

This is essential for Kepler.gl when we have to capture the selected feature and display a context menu near to the mouse position.

Signed-off-by: Giuseppe Macri <gmacri@uber.com>