### PR TITLE
Simplify onPan propagation check

### DIFF
--- a/modules/react-map-gl-draw/src/editor.js
+++ b/modules/react-map-gl-draw/src/editor.js
@@ -574,7 +574,7 @@ export default class Editor extends PureComponent<EditorProps, EditorState> {
     if (
       this._isVertex(evt.target) ||
       this._isLine(evt.target) ||
-      (this._matchesFeature(evt.target, this._getSelectedFeature()) && this.state.isDragging) ||
+      this.state.isDragging ||
       this.state.uncommittedLngLat !== null
     ) {
       evt.stopImmediatePropagation();


### PR DESCRIPTION
I don't notice any observable behavior changes with this, but it turns out the _matchesFeature check isn't necessary anymore since isDragging is always correctly set in #251.