### PR TITLE
Configuration option to disable dragging features

### DIFF
--- a/modules/react-map-gl-draw/src/edit-modes/editing-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/editing-mode.js
@@ -105,6 +105,9 @@ export default class EditingMode extends BaseMode {
       case ELEMENT_TYPE.FEATURE:
       case ELEMENT_TYPE.FILL:
       case ELEMENT_TYPE.SEGMENT:
+        if (!props.featuresDraggable) {
+          break;
+        }
         // dragging feature
         const dx = screenCoords[0] - lastPointerMoveEvent.screenCoords[0];
         const dy = screenCoords[1] - lastPointerMoveEvent.screenCoords[1];

--- a/modules/react-map-gl-draw/src/editor.js
+++ b/modules/react-map-gl-draw/src/editor.js
@@ -20,7 +20,8 @@ const defaultProps = {
   featureShape: 'circle',
   editHandleShape: 'rect',
   editHandleStyle: defaultEditHandleStyle,
-  featureStyle: defaultFeatureStyle
+  featureStyle: defaultFeatureStyle,
+  featuresDraggable: true
 };
 
 export default class Editor extends ModeHandler {

--- a/modules/react-map-gl-draw/src/mode-handler.js
+++ b/modules/react-map-gl-draw/src/mode-handler.js
@@ -145,7 +145,8 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
       selectedIndexes: [selectedFeatureIndex],
       lastPointerMoveEvent,
       viewport,
-      onEdit: this._onEdit
+      onEdit: this._onEdit,
+      featuresDraggable: this.props.featuresDraggable
     };
   }
 

--- a/modules/react-map-gl-draw/src/types.js
+++ b/modules/react-map-gl-draw/src/types.js
@@ -43,6 +43,9 @@ export type ModeProps<TData> = {
 
   // Callback used to update cursor
   onUpdateCursor: (cursor: ?string) => void
+
+  // Whether features are draggable in the mode
+  featuresDraggable: ?boolean,
 };
 
 export type EditorProps = {
@@ -55,6 +58,7 @@ export type EditorProps = {
   editHandleShape: Function | string,
   editHandleStyle: Function | any,
   featureStyle: Function | any,
+  featuresDraggable: ?boolean,
   onUpdate: Function,
   onSelect: Function
 };

--- a/modules/react-map-gl-draw/src/types.js
+++ b/modules/react-map-gl-draw/src/types.js
@@ -44,7 +44,7 @@ export type ModeProps<TData> = {
   // Callback used to update cursor
   onUpdateCursor: (cursor: ?string) => void,
 
-  // Whether features are draggable in the mode
+  // Whether features are draggable in this mode
   featuresDraggable: ?boolean
 };
 

--- a/modules/react-map-gl-draw/src/types.js
+++ b/modules/react-map-gl-draw/src/types.js
@@ -42,10 +42,10 @@ export type ModeProps<TData> = {
   onEdit: (editAction: EditAction<TData>) => void,
 
   // Callback used to update cursor
-  onUpdateCursor: (cursor: ?string) => void
+  onUpdateCursor: (cursor: ?string) => void,
 
   // Whether features are draggable in the mode
-  featuresDraggable: ?boolean,
+  featuresDraggable: ?boolean
 };
 
 export type EditorProps = {


### PR DESCRIPTION
We need to support a use case where dragging features in the edit mode is not allowed. I have added a parameter called `featuresDraggable` which is `true` by default. If `featuresDraggable === false`, dragging will be prevented in the editing mode.

Let me know if it's an interesting change for you and your thoughts on the API and missing pieces to make this change:

- is there any way to configure different modes? currently, `featuresDraggable` would only apply to the editing mode but other modes might have dragging as well
- what needs to be document and what tests would be needed make the change
- better way to disabled dragging? 