### PR TITLE
Fix deck 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,26 @@ _All notable changes to this project will be documented in this file. This proje
 
 <!-- INSERT HERE -->
 
+<!--
+## <<NEXT RELEASE>>
+
+### Breaking changes
+
+*  DrawCircleByBoundingBoxMode renamed to DrawCircleByDiameterMode (#314)
+*  The following props of `EditableGeoJsonLayer` are no longer proxied by nebula.gl, instead use deck.gl's [_subLayerProps](https://deck.gl/#/documentation/deckgl-api-reference/layers/composite-layer?section=_sublayerprops-object-experimental):
+  * `getLineDashArray`
+  * `lineDashJustified`
+  * `getTentativeLineDashArray`
+
+-->
+
 ## [0.16.0](https://github.com/uber/nebula.gl/compare/v0.15.0...v0.16.0) - 2019-09-25
 
 ### Changes
 
 * You can now style edit handles with an outline (which is now also the default) by supplying `getEditHandlePointOutlineColor`
 * Swap EditableGeoJsonLayer to use edit-modes module (#283)
-* Unwrap guide object when using `_sublayerProps` (#284)
+* Unwrap guide object when using `_subLayerProps` (#284)
 * Remove deprecated usage. #281 (#282)
 
 ### Breaking changes for `EditableGeoJsonLayer`

--- a/examples/advanced/example.js
+++ b/examples/advanced/example.js
@@ -951,7 +951,6 @@ export default class Example extends Component<
 
           getTentativeFillColor: () => [255, 0, 255, 100],
           getTentativeLineColor: () => [0, 0, 255, 255],
-          getTentativeLineDashArray: () => [0, 0],
           lineWidthMinPixels: 3
         })
       );

--- a/modules/layers/src/layers/editable-geojson-layer.js
+++ b/modules/layers/src/layers/editable-geojson-layer.js
@@ -118,7 +118,6 @@ const defaultProps = {
   pointRadiusScale: 1,
   pointRadiusMinPixels: 2,
   pointRadiusMaxPixels: Number.MAX_SAFE_INTEGER,
-  lineDashJustified: false,
   getLineColor: (feature, isSelected, mode) =>
     isSelected ? DEFAULT_SELECTED_LINE_COLOR : DEFAULT_LINE_COLOR,
   getFillColor: (feature, isSelected, mode) =>
@@ -126,11 +125,8 @@ const defaultProps = {
   getRadius: f =>
     (f && f.properties && f.properties.radius) || (f && f.properties && f.properties.size) || 1,
   getLineWidth: f => (f && f.properties && f.properties.lineWidth) || 3,
-  getLineDashArray: (feature, isSelected, mode) =>
-    isSelected && mode !== 'view' ? [7, 4] : [0, 0],
 
   // Tentative feature rendering
-  getTentativeLineDashArray: (f, mode) => [7, 4],
   getTentativeLineColor: f => DEFAULT_SELECTED_LINE_COLOR,
   getTentativeFillColor: f => DEFAULT_SELECTED_FILL_COLOR,
   getTentativeLineWidth: f => (f && f.properties && f.properties.lineWidth) || 3,
@@ -225,12 +221,10 @@ export default class EditableGeoJsonLayer extends EditableLayer {
       pointRadiusScale: this.props.pointRadiusScale,
       pointRadiusMinPixels: this.props.pointRadiusMinPixels,
       pointRadiusMaxPixels: this.props.pointRadiusMaxPixels,
-      lineDashJustified: this.props.lineDashJustified,
       getLineColor: this.selectionAwareAccessor(this.props.getLineColor),
       getFillColor: this.selectionAwareAccessor(this.props.getFillColor),
       getRadius: this.selectionAwareAccessor(this.props.getRadius),
       getLineWidth: this.selectionAwareAccessor(this.props.getLineWidth),
-      getLineDashArray: this.selectionAwareAccessor(this.props.getLineDashArray),
 
       _subLayerProps: {
         'line-strings': {
@@ -245,8 +239,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         getLineColor: [this.props.selectedFeatureIndexes, this.props.mode],
         getFillColor: [this.props.selectedFeatureIndexes, this.props.mode],
         getRadius: [this.props.selectedFeatureIndexes, this.props.mode],
-        getLineWidth: [this.props.selectedFeatureIndexes, this.props.mode],
-        getLineDashArray: [this.props.selectedFeatureIndexes, this.props.mode]
+        getLineWidth: [this.props.selectedFeatureIndexes, this.props.mode]
       }
     });
 
@@ -420,8 +413,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
         lineMiterLimit: this.props.lineMiterLimit,
         getLineColor: guideAccessor(this.props.getTentativeLineColor),
         getLineWidth: guideAccessor(this.props.getTentativeLineWidth),
-        getFillColor: guideAccessor(this.props.getTentativeFillColor),
-        getLineDashArray: guideAccessor(this.props.getTentativeLineDashArray)
+        getFillColor: guideAccessor(this.props.getTentativeFillColor)
       })
     );
 

--- a/modules/layers/src/layers/editable-layer.js
+++ b/modules/layers/src/layers/editable-layer.js
@@ -65,20 +65,23 @@ export default class EditableLayer extends CompositeLayer {
   }
 
   _removePointerHandlers() {
+    // https://github.com/uber/deck.gl/pull/4013
+    const element = this.context.deck.props.parent || this.context.gl.canvas;
+
     if (this.state._editableLayerState.pointerHandlers) {
-      this.context.gl.canvas.removeEventListener(
+      element.removeEventListener(
         'pointermove',
         this.state._editableLayerState.pointerHandlers.onPointerMove
       );
-      this.context.gl.canvas.removeEventListener(
+      element.removeEventListener(
         'pointerdown',
         this.state._editableLayerState.pointerHandlers.onPointerDown
       );
-      this.context.gl.canvas.removeEventListener(
+      element.removeEventListener(
         'pointerup',
         this.state._editableLayerState.pointerHandlers.onPointerUp
       );
-      this.context.gl.canvas.removeEventListener(
+      element.removeEventListener(
         'dblclick',
         this.state._editableLayerState.pointerHandlers.onDoubleClick
       );
@@ -87,6 +90,9 @@ export default class EditableLayer extends CompositeLayer {
   }
 
   _addPointerHandlers() {
+    // https://github.com/uber/deck.gl/pull/4013
+    const element = this.context.deck.props.parent || this.context.gl.canvas;
+
     this.state._editableLayerState.pointerHandlers = {
       onPointerMove: this._onPointerMove.bind(this),
       onPointerDown: this._onPointerDown.bind(this),
@@ -94,25 +100,25 @@ export default class EditableLayer extends CompositeLayer {
       onDoubleClick: this._onDoubleClick.bind(this)
     };
 
-    this.context.gl.canvas.addEventListener(
+    element.addEventListener(
       'pointermove',
       this.state._editableLayerState.pointerHandlers.onPointerMove
     );
-    this.context.gl.canvas.addEventListener(
+    element.addEventListener(
       'pointerdown',
       this.state._editableLayerState.pointerHandlers.onPointerDown
     );
-    this.context.gl.canvas.addEventListener(
+    element.addEventListener(
       'pointerup',
       this.state._editableLayerState.pointerHandlers.onPointerUp
     );
-    this.context.gl.canvas.addEventListener(
+    element.addEventListener(
       'dblclick',
       this.state._editableLayerState.pointerHandlers.onDoubleClick
     );
   }
 
-  _onDoubleClick(event: Object) {
+  _onDoubleClick(event: any) {
     const screenCoords = this.getScreenCoords(event);
     const mapCoords = this.getMapCoords(screenCoords);
     this.onDoubleClick({
@@ -121,7 +127,7 @@ export default class EditableLayer extends CompositeLayer {
     });
   }
 
-  _onPointerDown(event: Object) {
+  _onPointerDown(event: any) {
     const screenCoords = this.getScreenCoords(event);
     const mapCoords = this.getMapCoords(screenCoords);
 
@@ -144,7 +150,7 @@ export default class EditableLayer extends CompositeLayer {
     });
   }
 
-  _onPointerMove(event: Object) {
+  _onPointerMove(event: any) {
     const screenCoords = this.getScreenCoords(event);
     const mapCoords = this.getMapCoords(screenCoords);
 
@@ -208,7 +214,7 @@ export default class EditableLayer extends CompositeLayer {
     }
   }
 
-  _onPointerUp(event: Object) {
+  _onPointerUp(event: any) {
     const screenCoords = this.getScreenCoords(event);
     const mapCoords = this.getMapCoords(screenCoords);
 
@@ -253,7 +259,7 @@ export default class EditableLayer extends CompositeLayer {
     });
   }
 
-  getScreenCoords(pointerEvent: Object) {
+  getScreenCoords(pointerEvent: any) {
     return [
       pointerEvent.clientX - this.context.gl.canvas.getBoundingClientRect().x,
       pointerEvent.clientY - this.context.gl.canvas.getBoundingClientRect().y


### PR DESCRIPTION
Fixes the integration with deck.gl 8. I took out the line dash props since they're handled differently in deck.gl 8. Also, I had to put the same tweak on the event handling as https://github.com/uber/deck.gl/blame/1a8b5d495b2e3f7b139ec3559002a010d73f329b/modules/core/src/lib/deck.js#L601