### PR TITLE
Implement ability to drag and draw in certain modes

### DIFF
--- a/docs/api-reference/modes/overview.md
+++ b/docs/api-reference/modes/overview.md
@@ -91,6 +91,13 @@ User can draw a new `Polygon` feature with 90 degree corners (right angle) by cl
 
 User can draw a new rectangular `Polygon` feature by clicking two opposing corners of the rectangle.
 
+### ModeConfig
+
+The following options can be provided in the `modeConfig` object:
+
+* `dragToDraw` (optional):  `boolean`
+  * If `true`, user can click and drag instead of clicking twice. Note however, that the user will not be able to pan the map while drawing.
+
 ## [DrawRectangleUsingThreePointsMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/draw-rectangle-using-three-points-mode.js)
 
 User can draw a new rectangular `Polygon` feature by clicking three corners of the rectangle.
@@ -105,6 +112,8 @@ The following options can be provided in the `modeConfig` object:
 
 * `steps` (optional):  `x <number>`
   * If steps: `x` means the circle will be drawn using `x` number of points.
+* `dragToDraw` (optional):  `boolean`
+  * If `true`, user can click and drag instead of clicking twice. Note however, that the user will not be able to pan the map while drawing.
 
 ## [DrawCircleByDiameterMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/draw-circle-by-diameter-mode.js)
 
@@ -116,10 +125,19 @@ The following options can be provided in the `modeConfig` object:
 
 * `steps` (optional):  `x <number>`
   * If steps: `x` means the circle will be drawn using `x` number of points.
+* `dragToDraw` (optional):  `boolean`
+  * If `true`, user can click and drag instead of clicking twice. Note however, that the user will not be able to pan the map while drawing.
 
 ## [DrawEllipseByBoundingBoxMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/draw-ellipse-by-bounding-box-mode.js)
 
 User can draw a new ellipse shape `Polygon` feature by clicking two corners of bounding box.
+
+### ModeConfig
+
+The following options can be provided in the `modeConfig` object:
+
+* `dragToDraw` (optional):  `boolean`
+  * If `true`, user can click and drag instead of clicking twice. Note however, that the user will not be able to pan the map while drawing.
 
 ## [DrawEllipseUsingThreePointsMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/draw-ellipse-using-three-points-mode.js)
 

--- a/examples/advanced/example.js
+++ b/examples/advanced/example.js
@@ -212,24 +212,7 @@ export default class Example extends Component<
 
     this.state = {
       viewport: initialViewport,
-      testFeatures: {
-        type: 'FeatureCollection',
-        features: [
-          // {
-          //   type: 'Feature',
-          //   geometry: {
-          //     type: 'LineString',
-          //     coordinates: [
-          //       [-122.58294162392625, 37.73997969548399],
-          //       [-122.56565612792978, 37.762442784961586],
-          //       [-122.53809374809275, 37.75411959741058],
-          //       [-122.5321566784383, 37.73683194309388],
-          //       [-122.53400606155404, 37.717869419079825]
-          //     ]
-          //   }
-          // }
-        ]
-      },
+      testFeatures: sampleGeoJson,
       mode: DrawPolygonMode,
       modeConfig: null,
       pointsRemovable: true,
@@ -257,7 +240,7 @@ export default class Example extends Component<
   };
 
   _onLayerClick = (info: any) => {
-    // console.log('onLayerClick', info); // eslint-disable-line
+    console.log('onLayerClick', info); // eslint-disable-line
 
     if (this.state.mode !== ViewMode || this.state.selectionTool) {
       // don't change selection while editing
@@ -926,8 +909,6 @@ export default class Example extends Component<
       });
     }
 
-    console.log('rendering', featuresToInfoString(testFeatures));
-
     const editableGeoJsonLayer = new EditableGeoJsonLayer({
       id: 'geojson',
       data: testFeatures,
@@ -1063,6 +1044,22 @@ function featuresToInfoString(featureCollection: any): string {
   return JSON.stringify(info);
 }
 
-function getPositionCount(geometry) {
-  return JSON.stringify(geometry.coordinates);
+function getPositionCount(geometry): number {
+  const flatMap = (f, arr) => arr.reduce((x, y) => [...x, ...f(y)], []);
+
+  const { type, coordinates } = geometry;
+  switch (type) {
+    case 'Point':
+      return 1;
+    case 'LineString':
+    case 'MultiPoint':
+      return coordinates.length;
+    case 'Polygon':
+    case 'MultiLineString':
+      return flatMap(x => x, coordinates).length;
+    case 'MultiPolygon':
+      return flatMap(x => flatMap(y => y, x), coordinates).length;
+    default:
+      throw Error(`Unknown geometry type: ${type}`);
+  }
 }

--- a/modules/edit-modes/src/lib/two-click-polygon-mode.js
+++ b/modules/edit-modes/src/lib/two-click-polygon-mode.js
@@ -1,12 +1,49 @@
 // @flow
 
-import type { ClickEvent, PointerMoveEvent, ModeProps, GuideFeatureCollection } from '../types.js';
+import type {
+  ClickEvent,
+  StartDraggingEvent,
+  StopDraggingEvent,
+  PointerMoveEvent,
+  ModeProps,
+  GuideFeatureCollection
+} from '../types.js';
 import type { Polygon, FeatureCollection, FeatureOf, Position } from '../geojson-types.js';
 import { BaseGeoJsonEditMode } from './geojson-edit-mode.js';
 
 export class TwoClickPolygonMode extends BaseGeoJsonEditMode {
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {
+    if (props.modeConfig.dragToDraw) {
+      // handled in drag handlers
+      return;
+    }
+
     this.addClickSequence(event);
+
+    this.checkAndFinishPolygon(props);
+  }
+
+  handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>): void {
+    if (!props.modeConfig.dragToDraw) {
+      // handled in click handlers
+      return;
+    }
+
+    this.addClickSequence(event);
+    event.cancelPan();
+  }
+
+  handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>): void {
+    if (!props.modeConfig.dragToDraw) {
+      // handled in click handlers
+      return;
+    }
+    this.addClickSequence(event);
+
+    this.checkAndFinishPolygon(props);
+  }
+
+  checkAndFinishPolygon(props: ModeProps<FeatureCollection>) {
     const clickSequence = this.getClickSequence();
     const tentativeFeature = this.getTentativeGuide(props);
 

--- a/modules/edit-modes/src/lib/two-click-polygon-mode.js
+++ b/modules/edit-modes/src/lib/two-click-polygon-mode.js
@@ -13,7 +13,7 @@ import { BaseGeoJsonEditMode } from './geojson-edit-mode.js';
 
 export class TwoClickPolygonMode extends BaseGeoJsonEditMode {
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {
-    if (props.modeConfig.dragToDraw) {
+    if (props.modeConfig && props.modeConfig.dragToDraw) {
       // handled in drag handlers
       return;
     }
@@ -24,7 +24,7 @@ export class TwoClickPolygonMode extends BaseGeoJsonEditMode {
   }
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>): void {
-    if (!props.modeConfig.dragToDraw) {
+    if (!props.modeConfig || !props.modeConfig.dragToDraw) {
       // handled in click handlers
       return;
     }
@@ -34,7 +34,7 @@ export class TwoClickPolygonMode extends BaseGeoJsonEditMode {
   }
 
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>): void {
-    if (!props.modeConfig.dragToDraw) {
+    if (!props.modeConfig || !props.modeConfig.dragToDraw) {
       // handled in click handlers
       return;
     }

--- a/modules/edit-modes/test/lib/draw-rectangle-mode.test.js
+++ b/modules/edit-modes/test/lib/draw-rectangle-mode.test.js
@@ -1,0 +1,237 @@
+// @flow
+/* eslint-env jest */
+
+import turfArea from '@turf/area';
+import type { Feature, FeatureCollection } from '@nebula.gl/edit-modes';
+import { DrawRectangleMode } from '../../src/lib/draw-rectangle-mode.js';
+import {
+  createFeatureCollectionProps,
+  createFeatureCollection,
+  createClickEvent,
+  createPointerMoveEvent,
+  createStartDraggingEvent,
+  createStopDraggingEvent
+} from '../test-utils.js';
+import type { GeoJsonEditAction } from '../../src/lib/geojson-edit-mode.js';
+
+let featureCollection: FeatureCollection;
+let polygonFeature: Feature;
+let polygonFeatureIndex: number;
+
+let warnBefore;
+beforeEach(() => {
+  warnBefore = console.warn; // eslint-disable-line
+  // $FlowFixMe
+  console.warn = function() {}; // eslint-disable-line
+
+  featureCollection = createFeatureCollection();
+
+  const makeFlowHappy = featureCollection.features.find(f => f.geometry.type === 'Polygon');
+  if (!makeFlowHappy) {
+    throw new Error(`Need a Polygon in my setup`);
+  }
+  polygonFeature = makeFlowHappy;
+  polygonFeatureIndex = featureCollection.features.indexOf(polygonFeature);
+});
+
+afterEach(() => {
+  // $FlowFixMe
+  console.warn = warnBefore; // eslint-disable-line
+});
+
+describe('dragToDraw=false', () => {
+  it('sets tentative feature to a Polygon after first click', () => {
+    const mode = new DrawRectangleMode();
+
+    const props = createFeatureCollectionProps();
+    props.lastPointerMoveEvent = createPointerMoveEvent([1, 2]);
+    mode.handleClick(createClickEvent([1, 2]), props);
+    props.lastPointerMoveEvent = createPointerMoveEvent([2, 3]);
+
+    const tentativeFeature = mode.getTentativeGuide(props);
+
+    if (!tentativeFeature) {
+      throw new Error('Should have tentative feature');
+    }
+
+    expect(tentativeFeature.geometry).toEqual({
+      type: 'Polygon',
+      coordinates: [[[1, 2], [2, 2], [2, 3], [1, 3], [1, 2]]]
+    });
+  });
+
+  it('adds a new feature after two clicks', () => {
+    const mode = new DrawRectangleMode();
+
+    const props = createFeatureCollectionProps();
+    props.lastPointerMoveEvent = createPointerMoveEvent([1, 2]);
+    mode.handleClick(createClickEvent([1, 2]), props);
+    props.lastPointerMoveEvent = createPointerMoveEvent([2, 3]);
+    mode.handleClick(createClickEvent([2, 3]), props);
+
+    const expectedAction2: GeoJsonEditAction = {
+      editType: 'addFeature',
+      updatedData: {
+        ...props.data,
+        features: [
+          ...props.data.features,
+          {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+              type: 'Polygon',
+              coordinates: [[[1, 2], [2, 2], [2, 3], [1, 3], [1, 2]]]
+            }
+          }
+        ]
+      },
+      editContext: {
+        featureIndexes: [featureCollection.features.length]
+      }
+    };
+
+    expect(props.onEdit).toHaveBeenCalledTimes(1);
+    expect(props.onEdit.mock.calls[0][0]).toEqual(expectedAction2);
+  });
+});
+
+describe('dragToDraw=true', () => {
+  it('sets tentative feature to a Polygon after start dragging', () => {
+    const mode = new DrawRectangleMode();
+
+    const props = createFeatureCollectionProps({
+      modeConfig: {
+        dragToDraw: true
+      }
+    });
+    props.lastPointerMoveEvent = createPointerMoveEvent([1, 2]);
+    mode.handleStartDragging(createStartDraggingEvent([1, 2], [1, 2]), props);
+    props.lastPointerMoveEvent = createPointerMoveEvent([2, 3]);
+
+    const tentativeFeature = mode.getTentativeGuide(props);
+
+    if (!tentativeFeature) {
+      throw new Error('Should have tentative feature');
+    }
+
+    expect(tentativeFeature.geometry).toEqual({
+      type: 'Polygon',
+      coordinates: [[[1, 2], [2, 2], [2, 3], [1, 3], [1, 2]]]
+    });
+  });
+
+  it('adds a new feature after stop dragging', () => {
+    const mode = new DrawRectangleMode();
+
+    const props = createFeatureCollectionProps({
+      modeConfig: {
+        dragToDraw: true
+      }
+    });
+    props.lastPointerMoveEvent = createPointerMoveEvent([1, 2]);
+    mode.handleStartDragging(createStartDraggingEvent([1, 2], [1, 2]), props);
+    props.lastPointerMoveEvent = createPointerMoveEvent([2, 3]);
+    mode.handleStopDragging(createStopDraggingEvent([2, 3], [2, 3]), props);
+
+    const expectedAction2: GeoJsonEditAction = {
+      editType: 'addFeature',
+      updatedData: {
+        ...props.data,
+        features: [
+          ...props.data.features,
+          {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+              type: 'Polygon',
+              coordinates: [[[1, 2], [2, 2], [2, 3], [1, 3], [1, 2]]]
+            }
+          }
+        ]
+      },
+      editContext: {
+        featureIndexes: [featureCollection.features.length]
+      }
+    };
+
+    expect(props.onEdit).toHaveBeenCalledTimes(1);
+    expect(props.onEdit.mock.calls[0][0]).toEqual(expectedAction2);
+  });
+});
+
+describe('modeConfig.booleanOperation', () => {
+  describe('union', () => {
+    test('unions shapes', () => {
+      const mode = new DrawRectangleMode();
+
+      const props = createFeatureCollectionProps({
+        selectedIndexes: [polygonFeatureIndex],
+        modeConfig: { booleanOperation: 'union' }
+      });
+
+      const areaBefore = turfArea(featureCollection.features[polygonFeatureIndex]);
+
+      props.lastPointerMoveEvent = createPointerMoveEvent([0, 0]);
+      mode.handleClick(createClickEvent([0, 0]), props);
+      props.lastPointerMoveEvent = createPointerMoveEvent([2, 2]);
+      mode.handleClick(createClickEvent([2, 2]), props);
+
+      expect(props.onEdit).toHaveBeenCalledTimes(1);
+
+      const action = props.onEdit.mock.calls[0][0];
+      const areaAfter = turfArea(action.updatedData.features[polygonFeatureIndex]);
+
+      expect(areaAfter).toBeGreaterThan(areaBefore);
+    });
+  });
+
+  describe('difference', () => {
+    test('subtracts geometry', () => {
+      const mode = new DrawRectangleMode();
+
+      const props = createFeatureCollectionProps({
+        selectedIndexes: [polygonFeatureIndex],
+        modeConfig: { booleanOperation: 'difference' }
+      });
+
+      const areaBefore = turfArea(featureCollection.features[polygonFeatureIndex]);
+
+      props.lastPointerMoveEvent = createPointerMoveEvent([0, 0]);
+      mode.handleClick(createClickEvent([0, 0]), props);
+      props.lastPointerMoveEvent = createPointerMoveEvent([2, 2]);
+      mode.handleClick(createClickEvent([2, 2]), props);
+
+      expect(props.onEdit).toHaveBeenCalledTimes(1);
+
+      const action = props.onEdit.mock.calls[0][0];
+      const areaAfter = turfArea(action.updatedData.features[polygonFeatureIndex]);
+
+      expect(areaAfter).toBeLessThan(areaBefore);
+    });
+  });
+
+  describe('intersection', () => {
+    test('subtracts geometry', () => {
+      const mode = new DrawRectangleMode();
+
+      const props = createFeatureCollectionProps({
+        selectedIndexes: [polygonFeatureIndex],
+        modeConfig: { booleanOperation: 'intersection' }
+      });
+
+      const areaBefore = turfArea(featureCollection.features[polygonFeatureIndex]);
+
+      props.lastPointerMoveEvent = createPointerMoveEvent([0, 0]);
+      mode.handleClick(createClickEvent([0, 0]), props);
+      props.lastPointerMoveEvent = createPointerMoveEvent([2, 2]);
+      mode.handleClick(createClickEvent([2, 2]), props);
+
+      expect(props.onEdit).toHaveBeenCalledTimes(1);
+
+      const action = props.onEdit.mock.calls[0][0];
+      const areaAfter = turfArea(action.updatedData.features[polygonFeatureIndex]);
+
+      expect(areaAfter).toBeLessThan(areaBefore);
+    });
+  });
+});

--- a/modules/edit-modes/test/test-utils.js
+++ b/modules/edit-modes/test/test-utils.js
@@ -6,6 +6,7 @@ import type {
   ModeProps,
   ClickEvent,
   PointerMoveEvent,
+  StartDraggingEvent,
   StopDraggingEvent,
   Pick
 } from '../src/types.js';
@@ -258,7 +259,24 @@ export function createClickEvent(mapCoords: Position, picks: Pick[] = []): Click
   };
 }
 
-export function createPointerDragEvent(
+export function createStartDraggingEvent(
+  mapCoords: Position,
+  pointerDownMapCoords: Position,
+  picks: Pick[] = []
+): StartDraggingEvent {
+  return {
+    screenCoords: [-1, -1],
+    mapCoords,
+    picks,
+    pointerDownPicks: null,
+    pointerDownScreenCoords: [-1, -1],
+    pointerDownMapCoords,
+    cancelPan: jest.fn(),
+    sourceEvent: null
+  };
+}
+
+export function createStopDraggingEvent(
   mapCoords: Position,
   pointerDownMapCoords: Position,
   picks: Pick[] = []

--- a/modules/layers/src/layers/selection-layer.js
+++ b/modules/layers/src/layers/selection-layer.js
@@ -5,6 +5,7 @@ import { PolygonLayer } from '@deck.gl/layers';
 import { polygon } from '@turf/helpers';
 import turfBuffer from '@turf/buffer';
 import turfDifference from '@turf/difference';
+import { DrawRectangleMode, DrawPolygonMode, ViewMode } from '@nebula.gl/edit-modes';
 
 import EditableGeoJsonLayer from './editable-geojson-layer';
 
@@ -12,6 +13,15 @@ export const SELECTION_TYPE = {
   NONE: null,
   RECTANGLE: 'rectangle',
   POLYGON: 'polygon'
+};
+
+const MODE_MAP = {
+  [SELECTION_TYPE.RECTANGLE]: DrawRectangleMode,
+  [SELECTION_TYPE.POLYGON]: DrawPolygonMode
+};
+
+const MODE_CONFIG_MAP = {
+  [SELECTION_TYPE.RECTANGLE]: { dragToDraw: true }
 };
 
 const defaultProps = {
@@ -122,11 +132,8 @@ export default class SelectionLayer extends CompositeLayer {
   renderLayers() {
     const { pendingPolygonSelection } = this.state;
 
-    const mode =
-      {
-        [SELECTION_TYPE.RECTANGLE]: 'drawRectangle',
-        [SELECTION_TYPE.POLYGON]: 'drawPolygon'
-      }[this.props.selectionType] || 'view';
+    const mode = MODE_MAP[this.props.selectionType] || ViewMode;
+    const modeConfig = MODE_CONFIG_MAP[this.props.selectionType];
 
     const inheritedProps = {};
     PASS_THROUGH_PROPS.forEach(p => {
@@ -139,6 +146,7 @@ export default class SelectionLayer extends CompositeLayer {
           id: LAYER_ID_GEOJSON,
           pickable: true,
           mode,
+          modeConfig,
           selectedFeatureIndexes: [],
           data: EMPTY_DATA,
           onEdit: ({ updatedData, editType }) => {


### PR DESCRIPTION
For all modes that implement TwoClickPolygonMode, support dragging to draw instead of needing two clicks. Two clicks is still the default.

![dragToDraw](https://user-images.githubusercontent.com/469582/72868409-2cf5e300-3c9f-11ea-8239-6d6fa24abb42.gif)


Fixes #301


TODO:
* [ ] Documentation
* [ ] Tests