### PR TITLE
react-map-gl-draw: fix lagging between viewport and editor updating

### DIFF
--- a/modules/layers/test/lib/mode-handlers/draw-line-string-handler.test.js
+++ b/modules/layers/test/lib/mode-handlers/draw-line-string-handler.test.js
@@ -81,8 +81,7 @@ describe('when no selection', () => {
       },
       featureIndexes: [featureCollection.features.length],
       editContext: {
-      featureIndexes: [featureCollection.features.length],
-
+        featureIndexes: [featureCollection.features.length]
       }
     });
   });

--- a/modules/react-map-gl-draw/src/editor.js
+++ b/modules/react-map-gl-draw/src/editor.js
@@ -536,11 +536,10 @@ export default class Editor extends ModeHandler {
     );
   };
 
-  _renderEditor = () => {
+  _render = () => {
     const viewport = (this._context && this._context.viewport) || {};
     const { style } = this.props;
     const { width, height } = viewport;
-
     return (
       <div
         id="editor"
@@ -557,8 +556,4 @@ export default class Editor extends ModeHandler {
       </div>
     );
   };
-
-  render() {
-    return super.render(this._renderEditor());
-  }
 }

--- a/modules/react-map-gl-draw/src/mode-handler.js
+++ b/modules/react-map-gl-draw/src/mode-handler.js
@@ -472,7 +472,11 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
     return DRAWING_MODE.findIndex(m => m === mode) >= 0;
   }
 
-  render(child: any) {
+  _render() {
+    return <div />;
+  }
+
+  render() {
     return (
       <MapContext.Consumer>
         {context => {
@@ -483,7 +487,7 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
             return null;
           }
 
-          return child;
+          return this._render();
         }}
       </MapContext.Consumer>
     );


### PR DESCRIPTION
for https://github.com/uber/react-map-gl/issues/1004 and https://github.com/uber/nebula.gl/issues/306

child is created before the context populated, hence editor is always using the viewport data from last renderframe