### PR TITLE
react-map-gl-draw: fix onUpdate to callback when anything is updated

### DIFF
--- a/dev-docs/RFCs/v1.0/react-map-gl-draw.md
+++ b/dev-docs/RFCs/v1.0/react-map-gl-draw.md
@@ -26,7 +26,7 @@ Another `vis.gl` framework [Nebula.gl](http://nebula.gl) also provides geo editi
 - `clickRadius` (Number, optional) - Radius to detect features around a hovered or clicked point. Default value is `0`
 
 - `onSelect` (Function, Required) - callback when a feature is selected. Receives an object containing `selectedFeatureId`.
-- `onUpdate` (Function, Required) - callback when anything is updated. Receives one argument `features` that is the updated list of GeoJSON features.
+- `onUpdate` (Function, Required) - callback when any feature is updated. Receives one argument `features` that is the updated list of GeoJSON features.
 
 Feature object structure:
 

--- a/docs/api-reference/react-map-gl-draw/react-map-gl-draw.md
+++ b/docs/api-reference/react-map-gl-draw/react-map-gl-draw.md
@@ -23,7 +23,7 @@
   - `screenCoords`: screen coordinates of the clicked position.
   - `mapCoords`: map coordinates of the clicked position.
 
-- `onUpdate` (Function, Optional) - callback when anything is updated. Receives an object containing the following parameters
+- `onUpdate` (Function, Optional) - callback when any feature is updated. Receives an object containing the following parameters
   - `features` (Feature[]) - the updated list of GeoJSON features.
   - `editType` (String) -  `addFeature`, `addPosition`, `finishMovePosition`
   - `editContext` (Array) - list of edit objects, depend on `editType`, each object may contain `featureIndexes`, `editHandleIndexes`, `screenCoords`, `mapCoords`.

--- a/modules/react-map-gl-draw/README.md
+++ b/modules/react-map-gl-draw/README.md
@@ -23,7 +23,7 @@
   - `screenCoords`: screen coordinates of the clicked position.
   - `mapCoords`: map coordinates of the clicked position.
 
-- `onUpdate` (Function, Optional) - callback when anything is updated. Receives an object containing the following parameters
+- `onUpdate` (Function, Optional) - callback when any feature is updated. Receives an object containing the following parameters
   - `features` (Feature[]) - the updated list of GeoJSON features.
   - `editType` (String) -  `addFeature`, `addPosition`, `finishMovePosition`
   - `editContext` (Array) - list of edit objects, depend on `editType`, each object may contain `featureIndexes`, `editHandleIndexes`, `screenCoords`, `mapCoords`.

--- a/modules/react-map-gl-draw/src/mode-handler.js
+++ b/modules/react-map-gl-draw/src/mode-handler.js
@@ -263,7 +263,6 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
         break;
       default:
         break;
-
     }
   };
 

--- a/modules/react-map-gl-draw/src/mode-handler.js
+++ b/modules/react-map-gl-draw/src/mode-handler.js
@@ -227,10 +227,10 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
     }
   };
 
-  _onUpdate = (editAction: EditAction, isInternal: ?boolean) => {
+  _onUpdate = (editAction: EditAction) => {
     const { editType, updatedData, editContext } = editAction;
     this.setState({ featureCollection: new ImmutableFeatureCollection(updatedData) });
-    if (this.props.onUpdate && !isInternal) {
+    if (this.props.onUpdate) {
       this.props.onUpdate({
         data: updatedData && updatedData.features,
         editType,
@@ -243,14 +243,10 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
     const { mode } = this.props;
     const { editType, updatedData } = editAction;
 
+    this._onUpdate(editAction);
+
     switch (editType) {
-      case EDIT_TYPE.MOVE_POSITION:
-        // intermediate feature, do not need forward to application
-        // only need update editor internal state
-        this._onUpdate(editAction, true);
-        break;
       case EDIT_TYPE.ADD_FEATURE:
-        this._onUpdate(editAction);
         if (mode === MODES.DRAW_PATH) {
           const context = (editAction.editContext && editAction.editContext[0]) || {};
           const { screenCoords, mapCoords } = context;
@@ -265,13 +261,9 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
           });
         }
         break;
-      case EDIT_TYPE.ADD_POSITION:
-      case EDIT_TYPE.REMOVE_POSITION:
-      case EDIT_TYPE.FINISH_MOVE_POSITION:
-        this._onUpdate(editAction);
+      default:
         break;
 
-      default:
     }
   };
 


### PR DESCRIPTION
Issues: 
The documentation for `onUpdate` says that it is a callback for  _**when anything is updated**_. But one update is omitted from public availability as an "internal" update and the default in the switch case omits any that aren't specifically captured.

Fix onUpdate:

- Remove `EDIT_TYPE.MOVE_POSITION` as an "internal" update.
- Remove selected modes picked for emission as updates.
- Add call to `this._onUpdate` as the default case in the switch statement
- Remove ability to have updates flagged as internal.
