### PR TITLE
react-map-gl-draw: Closing polygon drawing on dblclick

### DIFF
--- a/modules/react-map-gl-draw/src/edit-modes/base-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/base-mode.js
@@ -24,6 +24,8 @@ export default class BaseMode {
 
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {}
 
+  handleDblClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {}
+
   handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {}
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {}

--- a/modules/react-map-gl-draw/src/edit-modes/draw-polygon-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/draw-polygon-mode.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ClickEvent, FeatureCollection } from '@nebula.gl/edit-modes';
+import type { ClickEvent, Feature, FeatureCollection } from '@nebula.gl/edit-modes';
 import uuid from 'uuid/v1';
 
 import type { ModeProps } from '../types';
@@ -22,30 +22,7 @@ export default class DrawPolygonMode extends BaseMode {
       // clicked an editHandle of a tentative feature
       if (pickedObject && pickedObject.index === 0) {
         this.setTentativeFeature(null);
-
-        // append point to the tail, close the polygon
-        const coordinates = getFeatureCoordinates(tentativeFeature);
-        if (!coordinates) {
-          return;
-        }
-
-        coordinates.push(coordinates[0]);
-
-        tentativeFeature = {
-          type: 'Feature',
-          properties: {
-            // TODO deprecate id
-            id: tentativeFeature.properties.id,
-            renderType: RENDER_TYPE.POLYGON
-          },
-          geometry: {
-            type: GEOJSON_TYPE.POLYGON,
-            coordinates: [coordinates]
-          }
-        };
-
-        const updatedData = data.addFeature(tentativeFeature).getObject();
-
+        const updatedData = data.addFeature(closePolygon(tentativeFeature)).getObject();
         props.onEdit({
           editType: EDIT_TYPE.ADD_FEATURE,
           updatedData,
@@ -79,6 +56,20 @@ export default class DrawPolygonMode extends BaseMode {
       };
 
       this.setTentativeFeature(tentativeFeature);
+    }
+  };
+
+  handleDblClick = (event: ClickEvent, props: ModeProps<FeatureCollection>) => {
+    const { data } = props;
+    const tentativeFeature = this.getTentativeFeature();
+    if (tentativeFeature) {
+      this.setTentativeFeature(null);
+      const updatedData = data.addFeature(closePolygon(tentativeFeature)).getObject();
+      props.onEdit({
+        editType: EDIT_TYPE.ADD_FEATURE,
+        updatedData,
+        editContext: null
+      });
     }
   };
 
@@ -122,5 +113,26 @@ export default class DrawPolygonMode extends BaseMode {
       tentativeFeature,
       editHandles
     };
+  };
+}
+
+function closePolygon(tentativeFeature: Feature): ?Feature {
+  // append point to the tail, close the polygon
+  const coordinates = getFeatureCoordinates(tentativeFeature);
+  if (!coordinates) {
+    return undefined;
+  }
+  coordinates.push(coordinates[0]);
+  return {
+    type: 'Feature',
+    properties: {
+      // TODO deprecate id
+      id: tentativeFeature.properties.id,
+      renderType: RENDER_TYPE.POLYGON
+    },
+    geometry: {
+      type: GEOJSON_TYPE.POLYGON,
+      coordinates: [coordinates]
+    }
   };
 }

--- a/modules/react-map-gl-draw/src/edit-modes/draw-polygon-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/draw-polygon-mode.js
@@ -117,7 +117,7 @@ export default class DrawPolygonMode extends BaseMode {
 }
 
 function closePolygon(tentativeFeature: Feature): ?Feature {
-  // append point to the tail, close the polygon
+  // append point to the tail to close the polygon
   const coordinates = getFeatureCoordinates(tentativeFeature);
   if (!coordinates) {
     return undefined;

--- a/modules/react-map-gl-draw/src/mode-handler.js
+++ b/modules/react-map-gl-draw/src/mode-handler.js
@@ -68,6 +68,7 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
     this._events = {
       anyclick: evt => this._onEvent(this._onClick, evt, true),
       click: evt => evt.stopImmediatePropagation(),
+      dblclick: evt => this._onEvent(this._onDblClick, evt, true),
       pointermove: evt => this._onEvent(this._onPointerMove, evt, true),
       pointerdown: evt => this._onEvent(this._onPointerDown, evt, true),
       pointerup: evt => this._onEvent(this._onPointerUp, evt, true),
@@ -341,6 +342,11 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
 
     const modeProps = this.getModeProps();
     this._modeHandler.handleClick(event, modeProps);
+  };
+
+  _onDblClick = (event: BaseEvent) => {
+    const modeProps = this.getModeProps();
+    this._modeHandler.handleDblClick(event, modeProps);
   };
 
   _onPointerMove = (event: BaseEvent) => {


### PR DESCRIPTION
This PR addresses the issue #330

We did some user testing for polygon drawing and realized that very few users discovered that they have to connect the last and the first points to close a polygon. Double click is a standard way of doing this. Hence, it's very important to support it.

cc @xintongxia