### PR TITLE
react-map-gl-draw: Starting to draw rect on mousedown not click

### DIFF
--- a/modules/react-map-gl-draw/src/edit-modes/base-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/base-mode.js
@@ -26,6 +26,8 @@ export default class BaseMode {
 
   handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {}
 
+  handlePan(event: ClickEvent, props: ModeProps<FeatureCollection>) {}
+
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {}
 
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {}

--- a/modules/react-map-gl-draw/src/edit-modes/draw-rectangle-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/draw-rectangle-mode.js
@@ -5,7 +5,7 @@ import type {
   ClickEvent,
   FeatureCollection,
   StopDraggingEvent
-} from '@ne bula.gl/edit-modes';
+} from '@nebula.gl/edit-modes';
 import uuid from 'uuid/v1';
 import type { ModeProps } from '../types';
 

--- a/modules/react-map-gl-draw/src/edit-modes/draw-rectangle-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/draw-rectangle-mode.js
@@ -1,6 +1,11 @@
 // @flow
 
-import type { Feature, ClickEvent, FeatureCollection, StopDraggingEvent } from '@ne bula.gl/edit-modes';
+import type {
+  Feature,
+  ClickEvent,
+  FeatureCollection,
+  StopDraggingEvent
+} from '@ne bula.gl/edit-modes';
 import uuid from 'uuid/v1';
 import type { ModeProps } from '../types';
 
@@ -9,7 +14,6 @@ import BaseMode from './base-mode';
 import { getFeatureCoordinates, updateRectanglePosition } from './utils';
 
 export default class DrawRectangleMode extends BaseMode {
-
   _initTentativeFeature = (event: ClickEvent, props: ModeProps<FeatureCollection>) => {
     this.setTentativeFeature({
       type: 'Feature',
@@ -64,8 +68,7 @@ export default class DrawRectangleMode extends BaseMode {
     });
   };
 
-  handleClick = (event: ClickEvent, props: ModeProps<FeatureCollection>) => {
-  };
+  handleClick = (event: ClickEvent, props: ModeProps<FeatureCollection>) => {};
 
   handleStartDragging = (event: StartDraggingEvent, props: ModeProps<FeatureCollection>) => {
     const tentativeFeature = this.getTentativeFeature();

--- a/modules/react-map-gl-draw/src/edit-modes/draw-rectangle-mode.js
+++ b/modules/react-map-gl-draw/src/edit-modes/draw-rectangle-mode.js
@@ -4,6 +4,7 @@ import type {
   Feature,
   ClickEvent,
   FeatureCollection,
+  StartDraggingEvent,
   StopDraggingEvent
 } from '@nebula.gl/edit-modes';
 import uuid from 'uuid/v1';
@@ -34,38 +35,40 @@ export default class DrawRectangleMode extends BaseMode {
     // close rectangle and commit
     const { data } = props;
     const tentativeFeature = this.getTentativeFeature();
-    // clear guides
-    this.setTentativeFeature(null);
+    if (tentativeFeature) {
+      // clear guides
+      this.setTentativeFeature(null);
 
-    let coordinates = updateRectanglePosition(tentativeFeature, 2, event.mapCoords);
-    if (!coordinates) {
-      return;
-    }
-
-    // close rectangle
-    coordinates = [...coordinates, coordinates[0]];
-
-    const nextTentativeFeature = {
-      type: 'Feature',
-      properties: {
-        // TODO deprecate id
-        id: tentativeFeature.properties.id,
-        renderType: RENDER_TYPE.RECTANGLE
-      },
-      geometry: {
-        type: GEOJSON_TYPE.POLYGON,
-        coordinates: [coordinates]
+      let coordinates = updateRectanglePosition(tentativeFeature, 2, event.mapCoords);
+      if (!coordinates) {
+        return;
       }
-    };
 
-    const updatedData = data.addFeature(nextTentativeFeature).getObject();
+      // close rectangle
+      coordinates = [...coordinates, coordinates[0]];
 
-    // commit rectangle
-    props.onEdit({
-      editType: EDIT_TYPE.ADD_FEATURE,
-      updatedData,
-      editContext: null
-    });
+      const nextTentativeFeature = {
+        type: 'Feature',
+        properties: {
+          // TODO deprecate id
+          id: tentativeFeature.properties.id,
+          renderType: RENDER_TYPE.RECTANGLE
+        },
+        geometry: {
+          type: GEOJSON_TYPE.POLYGON,
+          coordinates: [coordinates]
+        }
+      };
+
+      const updatedData = data.addFeature(nextTentativeFeature).getObject();
+
+      // commit rectangle
+      props.onEdit({
+        editType: EDIT_TYPE.ADD_FEATURE,
+        updatedData,
+        editContext: null
+      });
+    }
   };
 
   handleClick = (event: ClickEvent, props: ModeProps<FeatureCollection>) => {};

--- a/modules/react-map-gl-draw/src/mode-handler.js
+++ b/modules/react-map-gl-draw/src/mode-handler.js
@@ -73,7 +73,7 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
       pointerup: evt => this._onEvent(this._onPointerUp, evt, true),
       panmove: evt => this._onEvent(this._onPan, evt, false),
       panstart: evt => this._onEvent(this._onPan, evt, false),
-      panend: evt => this._onEvent(this._onPan, evt, false)
+      panend: evt => this._onEvent(this._onPan, evt, false),
     };
   }
 
@@ -428,6 +428,7 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
     if (isDragging) {
       event.sourceEvent.stopImmediatePropagation();
     }
+    this._modeHandler.handlePan(event, this.getModeProps());
   };
 
   /* HELPERS */

--- a/modules/react-map-gl-draw/src/mode-handler.js
+++ b/modules/react-map-gl-draw/src/mode-handler.js
@@ -73,7 +73,7 @@ export default class ModeHandler extends PureComponent<EditorProps, EditorState>
       pointerup: evt => this._onEvent(this._onPointerUp, evt, true),
       panmove: evt => this._onEvent(this._onPan, evt, false),
       panstart: evt => this._onEvent(this._onPan, evt, false),
-      panend: evt => this._onEvent(this._onPan, evt, false),
+      panend: evt => this._onEvent(this._onPan, evt, false)
     };
   }
 


### PR DESCRIPTION
Currently, to start drawing a rectangle you need to click and release the mouse. We did some user testing and realized that many users were confused by that. They expected the drawing to be initiated on mousedown, not after completing a click. This PR introduces the change.

This is also how rectangle drawing works on http://geojson.io/

It would be good in addition to still support map panning in the rect drawing mode. Many GIS tools (e.g. QGIS) let you pan the map while holding space bar while in selection by drawing mode. I tried to adding key event handlers for this, but for some reason that didn't work (they were never called):
![image](https://user-images.githubusercontent.com/351828/75460967-6991ba00-5982-11ea-97d1-c5f5b73c970c.png)

I realize that you might not necessarily agree with the proposed change. But I'd like at least to discuss the possibility with you, because it's a kind of a blocker for us.