### PR TITLE
De-structure coordinates prop to avoid passing to the `div`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,9 @@ module.exports = {
     'func-style': 'off',
 
     /* Use the 'query-string' module instead */
-    'no-restricted-imports': ['error', 'querystring']
+    'no-restricted-imports': ['error', 'querystring'],
+
+    'no-unused-vars': ['error', { args: 'none', 'ignoreRestSiblings': true }]
   },
   globals: {
     Buffer: true,

--- a/modules/overlays/src/html-overlay-item.tsx
+++ b/modules/overlays/src/html-overlay-item.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 export default class HtmlOverlayItem extends React.Component<Props> {
   render() {
-    const { x, y, children, style, ...props } = this.props;
+    const { x, y, children, style, coordinates, ...props } = this.props;
 
     return (
       //@ts-ignore


### PR DESCRIPTION
Otherwise, it generates the following snapshot:

```
         <div
     +     coordinates={
     +       Array [
     +         200,
     +         200,
     +       ]
     +     }
           style={
```