### PR TITLE
docs: add note about HtmlOverlayItem must be direct children of Overlay

### DIFF
--- a/docs/api-reference/overlays/html-overlay-item.md
+++ b/docs/api-reference/overlays/html-overlay-item.md
@@ -4,6 +4,7 @@ This is an HTML item that will be rendered inside
 [HtmlOverlay](/docs/api-reference/overlays/html-overlay) or
 [HtmlClusterOverlay](/docs/api-reference/overlays/html-cluster-overlay).
 
+Note: `HtmlOverlayItem` **must** be direct children of `HtmlOverlay` or `HtmlClusterOverlay`.
 
 ```jsx
 return (


### PR DESCRIPTION
question: should `HtmlOverlayItem` be able to be nested inside children components inside an `Overlay`?