### PR TITLE
Document the data property passed to onUpdate listeners

### DIFF
--- a/docs/api-reference/react-map-gl-draw/react-map-gl-draw.md
+++ b/docs/api-reference/react-map-gl-draw/react-map-gl-draw.md
@@ -24,7 +24,7 @@
   - `mapCoords`: map coordinates of the clicked position.
 
 - `onUpdate` (Function, Optional) - callback when any feature is updated. Receives an object containing the following parameters
-  - `features` (Feature[]) - the updated list of GeoJSON features.
+  - `data` (Feature[]) - the updated list of GeoJSON features.
   - `editType` (String) -  `addFeature`, `addPosition`, `finishMovePosition`
   - `editContext` (Array) - list of edit objects, depend on `editType`, each object may contain `featureIndexes`, `editHandleIndexes`, `screenCoords`, `mapCoords`.
 

--- a/modules/react-map-gl-draw/README.md
+++ b/modules/react-map-gl-draw/README.md
@@ -24,7 +24,7 @@
   - `mapCoords`: map coordinates of the clicked position.
 
 - `onUpdate` (Function, Optional) - callback when any feature is updated. Receives an object containing the following parameters
-  - `features` (Feature[]) - the updated list of GeoJSON features.
+  - `data` (Feature[]) - the updated list of GeoJSON features.
   - `editType` (String) -  `addFeature`, `addPosition`, `finishMovePosition`
   - `editContext` (Array) - list of edit objects, depend on `editType`, each object may contain `featureIndexes`, `editHandleIndexes`, `screenCoords`, `mapCoords`.
 


### PR DESCRIPTION
It looks like the object passed to the `onUpdate` function has a `data` property instead of `features`.

https://github.com/uber/nebula.gl/blob/20613f8697f1153d52d6af811af4ef298a231fc3/modules/react-map-gl-draw/src/mode-handler.tsx#L223-L227
