### PR TITLE
update gitignore to exclude typescript out dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,12 @@ coverage/
 *.rar
 .vscode
 
+# typescript generated 
+./lib
+
 # copied as part of a build step
 modules/main/README.md
 modules/edit-modes/README.md
 modules/editor/README.md
 modules/layers/README.md
+


### PR DESCRIPTION
https://github.com/uber/nebula.gl/blob/master/tsconfig.json#L10

Should this output `lib` be excluded?