### PR TITLE
Correct the document for DeckGL import

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ yarn add @deck.gl/layers
 [EditableGeoJsonLayer](/docs/api-reference/layers/editable-geojson-layer.md) is implemented as a [deck.gl](https://deck.gl) layer. It provides the ability to view and edit multiple types of geometry formatted as [GeoJSON](https://tools.ietf.org/html/rfc7946) (an open standard format for geometry) including polygons, lines, and points.
 
 ```js
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import { EditableGeoJsonLayer, DrawPolygonMode } from 'nebula.gl';
 
 const myFeatureCollection = {
   type: 'FeatureCollection',
   features: [
     /* insert features here */
-  ]
+  ],
 };
 
 const selectedFeatureIndexes = [];
 
 class App extends React.Component {
   state = {
-    data: myFeatureCollection
+    data: myFeatureCollection,
   };
 
   render() {
@@ -93,7 +93,7 @@ class App extends React.Component {
         this.setState({
           data: updatedData,
         });
-      }
+      },
     });
 
     return <DeckGL {...this.props.viewport} layers={[layer]} />;

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -3,7 +3,7 @@
 The Editable GeoJSON layer accepts a [GeoJSON](http://geojson.org) `FeatureCollection` and renders the features as editable polygons, lines, and points.
 
 ```js
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import { EditableGeoJsonLayer, DrawPolygonMode } from 'nebula.gl';
 
 const myFeatureCollection = {

--- a/docs/api-reference/layers/mesh-layer.md
+++ b/docs/api-reference/layers/mesh-layer.md
@@ -3,7 +3,7 @@
 The Mesh Layer renders a number of arbitrary geometries. For example, a fleet of 3d cars each with a position and an orientation over the map.
 
 ```js
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import { MeshLayer } from '@deck.gl/experimental-layers';
 import { CubeGeometry } from 'luma.gl';
 

--- a/examples/codesandbox/examples.old.txt
+++ b/examples/codesandbox/examples.old.txt
@@ -1,7 +1,7 @@
 import window from 'global/window';
 import * as React from 'react';
 import MapGL from 'react-map-gl';
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import { featureCollection, point } from '@turf/helpers';
 
 import { EditableGeoJsonLayer } from 'nebula.gl';


### PR DESCRIPTION
Based on the this issue, https://github.com/visgl/deck.gl/issues/4711. 
The correct usage of import DeckGL is `import DeckGL from '@deck.gl/react'`, and this change fix the imports for documents to avoid misleading. 