### PR TITLE
Fix getScreenCoords for Edge Browser

### DIFF
--- a/modules/layers/src/layers/editable-layer.ts
+++ b/modules/layers/src/layers/editable-layer.ts
@@ -250,9 +250,9 @@ export default class EditableLayer extends CompositeLayer<any> {
   getScreenCoords(pointerEvent: any) {
     return [
       pointerEvent.clientX -
-        (this.context.gl.canvas as HTMLCanvasElement).getBoundingClientRect().x,
+        (this.context.gl.canvas as HTMLCanvasElement).getBoundingClientRect().left,
       pointerEvent.clientY -
-        (this.context.gl.canvas as HTMLCanvasElement).getBoundingClientRect().y,
+        (this.context.gl.canvas as HTMLCanvasElement).getBoundingClientRect().top,
     ];
   }
 


### PR DESCRIPTION
Microsoft Edge getBoundingClientRect doesn't support `.x` or `.y`.  In Edge, I would receive an `invalid pixel coordinate` error for mouse events.