### PR TITLE
Expose edit-modes utils

### DIFF
--- a/modules/edit-modes/src/index.ts
+++ b/modules/edit-modes/src/index.ts
@@ -81,4 +81,5 @@ export type {
 } from './geojson-types';
 
 // Utils
-export * as utils from './utils';
+import * as utils from './utils';
+export { utils };

--- a/modules/edit-modes/src/index.ts
+++ b/modules/edit-modes/src/index.ts
@@ -79,3 +79,6 @@ export type {
   FeatureCollection,
   AnyGeoJson,
 } from './geojson-types';
+
+// Utils
+export * as utils from './utils';


### PR DESCRIPTION
Exposes edit-modes' utils as `utils` from `index.ts`

Resolves #421. 