### PR TITLE
react-map-gl-draw: Handle lastPointerMoveEvent null case

### DIFF
--- a/modules/react-map-gl-draw/src/edit-modes/editing-mode.ts
+++ b/modules/react-map-gl-draw/src/edit-modes/editing-mode.ts
@@ -261,6 +261,13 @@ export default class EditingMode extends BaseMode {
   }
 
   _getCursorEditHandle = (event: PointerMoveEvent, feature: Feature) => {
+    // event can be null when the user has not interacted with the map whatsoever
+    // and therefore props.lastPointerMoveEvent is still null
+    // returning null here means we can e.g. set a featureIndex without requiring an event
+    if (!event) {
+      return null;
+    }
+
     // @ts-ignore
     const { isDragging, picks } = event;
     // if not pick segment


### PR DESCRIPTION
`lastPointerMoveEvent` is initialised as `null`. If the user does not interact with the map, i.e. no `PointerMoveEvent` has been registered, a call to `_getCursorEditHandle()` will fail here: `const { isDragging, picks } = event;`, as event is still `null`.

Our use case is that we want to be able to set the `selectedFeatureIndex` from outside the map component, without requiring the user to have interacted with the map.