### PR TITLE
feat: Convert class properties to overridable methods.

### DIFF
--- a/modules/react-map-gl-draw/src/edit-modes/base-mode.ts
+++ b/modules/react-map-gl-draw/src/edit-modes/base-mode.ts
@@ -46,17 +46,17 @@ export default class BaseMode implements EditMode<FeatureCollection, GuideFeatur
   }
   handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>): void {}
 
-  getTentativeFeature = () => {
+  getTentativeFeature() {
     return this._tentativeFeature;
-  };
+  }
 
-  getEditHandles = () => {
+  getEditHandles() {
     return this._editHandles;
-  };
+  }
 
-  setTentativeFeature = (feature: Feature) => {
+  setTentativeFeature(feature: Feature) {
     this._tentativeFeature = feature;
-  };
+  }
 
   getEditHandlesFromFeature(feature: Feature, featureIndex: number | null | undefined) {
     const coordinates = getFeatureCoordinates(feature);
@@ -83,10 +83,7 @@ export default class BaseMode implements EditMode<FeatureCollection, GuideFeatur
     });
   }
 
-  getSelectedFeature = (
-    props: ModeProps<FeatureCollection>,
-    featureIndex: number | null | undefined
-  ) => {
+  getSelectedFeature(props: ModeProps<FeatureCollection>, featureIndex: number | null | undefined) {
     const { data, selectedIndexes } = props;
     // @ts-ignore
     const features = data && data.features;
@@ -96,5 +93,5 @@ export default class BaseMode implements EditMode<FeatureCollection, GuideFeatur
       : selectedIndexes && selectedIndexes[0];
 
     return features && features[selectedIndex];
-  };
+  }
 }

--- a/modules/react-map-gl-draw/src/edit-modes/editing-mode.ts
+++ b/modules/react-map-gl-draw/src/edit-modes/editing-mode.ts
@@ -19,7 +19,7 @@ import {
 } from './utils';
 
 export default class EditingMode extends BaseMode {
-  handleClick = (event: ClickEvent, props: ModeProps<FeatureCollection>) => {
+  handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {
     const picked = event.picks && event.picks[0];
     const selectedFeatureIndex = props.selectedIndexes && props.selectedIndexes[0];
     // @ts-ignore
@@ -66,7 +66,7 @@ export default class EditingMode extends BaseMode {
         ],
       });
     }
-  };
+  }
 
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
     // replace point
@@ -89,10 +89,10 @@ export default class EditingMode extends BaseMode {
     }
   }
 
-  _handleDragging = (
+  _handleDragging(
     event: PointerMoveEvent | StopDraggingEvent,
     props: ModeProps<FeatureCollection>
-  ) => {
+  ) {
     const { onEdit } = props;
     // @ts-ignore
     const selectedFeature = this.getSelectedFeature(props);
@@ -150,9 +150,9 @@ export default class EditingMode extends BaseMode {
 
       default:
     }
-  };
+  }
 
-  handlePointerMove = (event: PointerMoveEvent, props: ModeProps<FeatureCollection>) => {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
     // no selected feature
     // @ts-ignore
     const selectedFeature = this.getSelectedFeature(props);
@@ -165,10 +165,10 @@ export default class EditingMode extends BaseMode {
     }
 
     this._handleDragging(event, props);
-  };
+  }
 
   // TODO - refactor
-  _updateFeature = (props: ModeProps<FeatureCollection>, type: string, options: any = {}) => {
+  _updateFeature(props: ModeProps<FeatureCollection>, type: string, options: any = {}) {
     const { data, selectedIndexes, viewport } = props;
 
     const featureIndex = selectedIndexes && selectedIndexes[0];
@@ -243,7 +243,7 @@ export default class EditingMode extends BaseMode {
       default:
         return data && new ImmutableFeatureCollection(data).getObject();
     }
-  };
+  }
 
   _getPointOnSegment(feature: Feature, picked: any, pickedMapCoords: Position) {
     const coordinates = getFeatureCoordinates(feature);
@@ -260,7 +260,7 @@ export default class EditingMode extends BaseMode {
     );
   }
 
-  _getCursorEditHandle = (event: PointerMoveEvent, feature: Feature) => {
+  _getCursorEditHandle(event: PointerMoveEvent, feature: Feature) {
     // @ts-ignore
     const { isDragging, picks } = event;
     // if not pick segment
@@ -298,9 +298,9 @@ export default class EditingMode extends BaseMode {
         coordinates: insertMapCoords,
       },
     };
-  };
+  }
   // @ts-ignore
-  getGuides = (props: ModeProps<FeatureCollection>) => {
+  getGuides(props: ModeProps<FeatureCollection>) {
     // @ts-ignore
     const selectedFeature = this.getSelectedFeature(props);
     const selectedFeatureIndex = props.selectedIndexes && props.selectedIndexes[0];
@@ -325,5 +325,5 @@ export default class EditingMode extends BaseMode {
       type: 'FeatureCollection',
       features: editHandles.length ? editHandles : null,
     };
-  };
+  }
 }


### PR DESCRIPTION
The usage of class properties (via babel-plugin) prevents overrides for that methods when extending. Now EditMode can be extended and all methods can be customized.