### PR TITLE
Refactor Edit Modes to support updateTentativeFeature edit type

### DIFF
--- a/modules/edit-modes/src/lib/draw-90degree-polygon-mode.ts
+++ b/modules/edit-modes/src/lib/draw-90degree-polygon-mode.ts
@@ -8,22 +8,20 @@ import {
   getPickedEditHandle,
   getEditHandlesForGeometry,
 } from '../utils';
-import { ClickEvent, PointerMoveEvent, ModeProps, GuideFeatureCollection } from '../types';
+import {
+  ClickEvent,
+  PointerMoveEvent,
+  ModeProps,
+  GuideFeatureCollection,
+  TentativeFeature,
+} from '../types';
 import { Polygon, LineString, Position, FeatureCollection } from '../geojson-types';
 import { GeoJsonEditMode } from './geojson-edit-mode';
 
 export class Draw90DegreePolygonMode extends GeoJsonEditMode {
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
-    const guides: GuideFeatureCollection = {
-      type: 'FeatureCollection',
-      features: [],
-    };
-
+  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
     const clickSequence = this.getClickSequence();
 
-    if (clickSequence.length === 0 || !props.lastPointerMoveEvent) {
-      return guides;
-    }
     const { mapCoords } = props.lastPointerMoveEvent;
 
     let p3;
@@ -63,6 +61,22 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
       };
     }
 
+    return tentativeFeature;
+  }
+
+  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+    const guides: GuideFeatureCollection = {
+      type: 'FeatureCollection',
+      features: [],
+    };
+
+    const clickSequence = this.getClickSequence();
+
+    if (clickSequence.length === 0 || !props.lastPointerMoveEvent) {
+      return guides;
+    }
+    const tentativeFeature = this.createTentativeFeature(props);
+
     guides.features.push(tentativeFeature);
 
     guides.features = guides.features.concat(
@@ -75,8 +89,9 @@ export class Draw90DegreePolygonMode extends GeoJsonEditMode {
     return guides;
   }
 
-  handlePointerMove({ mapCoords }: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
     props.onUpdateCursor('cell');
+    super.handlePointerMove(event, props);
   }
 
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {

--- a/modules/edit-modes/src/lib/draw-polygon-mode.ts
+++ b/modules/edit-modes/src/lib/draw-polygon-mode.ts
@@ -1,19 +1,20 @@
-import { ClickEvent, PointerMoveEvent, ModeProps, GuideFeatureCollection } from '../types';
+import {
+  ClickEvent,
+  PointerMoveEvent,
+  ModeProps,
+  GuideFeatureCollection,
+  TentativeFeature,
+} from '../types';
 import { Polygon, FeatureCollection } from '../geojson-types';
 import { getPickedEditHandle } from '../utils';
 import { GeoJsonEditMode } from './geojson-edit-mode';
 
 export class DrawPolygonMode extends GeoJsonEditMode {
-  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
     const { lastPointerMoveEvent } = props;
     const clickSequence = this.getClickSequence();
 
     const lastCoords = lastPointerMoveEvent ? [lastPointerMoveEvent.mapCoords] : [];
-
-    const guides = {
-      type: 'FeatureCollection',
-      features: [],
-    };
 
     let tentativeFeature;
     if (clickSequence.length === 1 || clickSequence.length === 2) {
@@ -40,6 +41,18 @@ export class DrawPolygonMode extends GeoJsonEditMode {
       };
     }
 
+    return tentativeFeature;
+  }
+
+  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+    const clickSequence = this.getClickSequence();
+
+    const guides = {
+      type: 'FeatureCollection',
+      features: [],
+    };
+
+    const tentativeFeature = this.createTentativeFeature(props);
     if (tentativeFeature) {
       guides.features.push(tentativeFeature);
     }
@@ -125,7 +138,8 @@ export class DrawPolygonMode extends GeoJsonEditMode {
       }
     }
   }
-  handlePointerMove({ mapCoords }: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
     props.onUpdateCursor('cell');
+    super.handlePointerMove(event, props);
   }
 }

--- a/modules/edit-modes/src/lib/geojson-edit-mode.ts
+++ b/modules/edit-modes/src/lib/geojson-edit-mode.ts
@@ -238,8 +238,23 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
     return this.getAddFeatureAction(featureOrGeometry, props.data);
   }
 
+  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+    return null;
+  }
+
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>): void {}
-  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {}
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+    const tentativeFeature = this.createTentativeFeature(props);
+    if (tentativeFeature) {
+      props.onEdit({
+        updatedData: props.data,
+        editType: 'updateTentativeFeature',
+        editContext: {
+          feature: tentativeFeature,
+        },
+      });
+    }
+  }
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>): void {}
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>): void {}
   handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>): void {}

--- a/modules/edit-modes/src/lib/three-click-polygon-mode.ts
+++ b/modules/edit-modes/src/lib/three-click-polygon-mode.ts
@@ -1,4 +1,10 @@
-import { ClickEvent, PointerMoveEvent, ModeProps, GuideFeatureCollection } from '../types';
+import {
+  ClickEvent,
+  PointerMoveEvent,
+  ModeProps,
+  GuideFeatureCollection,
+  TentativeFeature,
+} from '../types';
 import { Position, Polygon, FeatureOf, FeatureCollection } from '../geojson-types';
 import { GeoJsonEditMode } from './geojson-edit-mode';
 
@@ -81,5 +87,25 @@ export class ThreeClickPolygonMode extends GeoJsonEditMode {
 
   handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
     props.onUpdateCursor('cell');
+    super.handlePointerMove(event, props);
+  }
+
+  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+    const { lastPointerMoveEvent } = props;
+    const clickSequence = this.getClickSequence();
+
+    const lastCoords = lastPointerMoveEvent ? [lastPointerMoveEvent.mapCoords] : [];
+
+    let tentativeFeature;
+    if (clickSequence.length === 2) {
+      tentativeFeature = this.getThreeClickPolygon(
+        clickSequence[0],
+        clickSequence[1],
+        lastCoords[0],
+        props.modeConfig
+      );
+    }
+
+    return tentativeFeature;
   }
 }

--- a/modules/edit-modes/src/lib/two-click-polygon-mode.ts
+++ b/modules/edit-modes/src/lib/two-click-polygon-mode.ts
@@ -5,6 +5,7 @@ import {
   PointerMoveEvent,
   ModeProps,
   GuideFeatureCollection,
+  TentativeFeature,
 } from '../types';
 import { Polygon, FeatureCollection, FeatureOf, Position } from '../geojson-types';
 import { GeoJsonEditMode } from './geojson-edit-mode';
@@ -112,5 +113,20 @@ export class TwoClickPolygonMode extends GeoJsonEditMode {
 
   handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
     props.onUpdateCursor('cell');
+    super.handlePointerMove(event, props);
+  }
+
+  createTentativeFeature(props: ModeProps<FeatureCollection>): TentativeFeature {
+    const { lastPointerMoveEvent } = props;
+    const clickSequence = this.getClickSequence();
+
+    const lastCoords = lastPointerMoveEvent ? [lastPointerMoveEvent.mapCoords] : [];
+
+    let tentativeFeature;
+    if (clickSequence.length === 1) {
+      tentativeFeature = this.getTwoClickPolygon(clickSequence[0], lastCoords[0], props.modeConfig);
+    }
+
+    return tentativeFeature;
   }
 }

--- a/modules/layers/src/layers/editable-h3-layer.ts
+++ b/modules/layers/src/layers/editable-h3-layer.ts
@@ -1,0 +1,81 @@
+/* eslint-env browser */
+
+import { CompositeLayer } from '@deck.gl/layers';
+
+export default class EditableH3Layer extends CompositeLayer {
+  static layerName = 'EditableH3Layer';
+  static defaultProps = defaultProps;
+
+  renderLayers() {
+    // TODO: call this.getSubLayerProps({
+
+    const layers: any = [
+      new EditableGeoJsonLayer({
+        data: [],
+        onEdit: ({ updatedData }) => {
+          const cells = getDerivedH3Cells(updatedData);
+          if (!this.props.booleanOperation) {
+            this.props.onEdit(cells);
+          } else if ('union') {
+            this.props.onEdit(this.props.data + cells);
+          } else if ('union') {
+            this.props.onEdit(this.props.data - cells);
+          }
+        },
+      }),
+
+      new H3Layer(
+        this.getSubLayerProps({
+          id: 'hexagons',
+          data: this.props.data,
+          color: this.props.colorH3,
+        })
+      ),
+
+      // don't do this
+      // new H3Layer({
+      //   data: this.props.data,
+      // }),
+    ];
+
+    return layers;
+  }
+}
+
+function useState(stuff) {
+  return [stuff, stuff];
+}
+
+export function MyComponent() {
+  const [h3Cells, setH3Cells] = useState([]);
+
+  const layer = new EditableH3Layer({
+    data: h3Cells,
+    onEdit: ({ updatedData }) => setH3Cells(updatedData),
+
+    h3Resulution: 12,
+
+    // when drawing new
+    mode: DrawPolygonMode,
+
+    // can do this
+    // _subLayerProps: {
+    //   hexagons: { color: 'red' }
+
+    // no need to do this
+    // colorPolygons: 'blue',
+    // colorH3: 'red',
+
+    // to add or remove from hexagons
+    // booleanOperation: 'union' | 'difference'
+
+    // this is the way EditableGeoJsonLayer does it
+    // when you add to shape (union),
+    // mode: DrawPolygonMode,
+    // modeConfig: { booleanOperation: 'union' }
+
+    // when you add to shape (difference),
+    // mode: DrawPolygonMode,
+    // modeConfig: { booleanOperation: 'union' }
+  });
+}


### PR DESCRIPTION
This change refactors the following GeoJsonEditMode to support the new 'updateTentativeFeature' edit type:

- Draw90DegreePolygonMode
- DrawPolygonMode (and all extended modes)
- GeoJsonEditMode
- TwoClickPolygonMode (and all extended modes)
- ThreeClickPolygonMode (and all extended modes)

'updateTentativeFeature' is a new edit type meant to be fired whenever a polygonal shape is near completion, and the user continues to drag the cursor mid-editing. It fires on pointer move. The tentative feature created is different for each mode. Tested for all of the above modes.

This edit type will be used to update a cluster of hexes on pointer move in an EditableH3Layer.