### PR TITLE
Remove polygon fill from bounding guide in rotate and scale edit modes and fix scale mode cursor

### DIFF
--- a/modules/edit-modes/src/lib/rotate-mode.ts
+++ b/modules/edit-modes/src/lib/rotate-mode.ts
@@ -59,7 +59,7 @@ export class RotateMode extends GeoJsonEditMode {
     let topEdgeMidpointCoords = null;
     let longestEdgeLength = 0;
 
-    coordEach(boundingBox, coord => {
+    coordEach(boundingBox, (coord) => {
       if (previousCoord) {
         // @ts-ignore
         const edgeMidpoint = getIntermediatePosition(coord, previousCoord);
@@ -87,7 +87,13 @@ export class RotateMode extends GeoJsonEditMode {
       editHandleType: 'rotate',
     });
     // @ts-ignore
-    return featureCollection([polygonToLine(boundingBox), rotateHandle, lineFromEnvelopeToRotateHandle]);
+    return featureCollection([
+      // @ts-ignore
+      polygonToLine(boundingBox),
+      // @ts-ignore
+      rotateHandle,
+      lineFromEnvelopeToRotateHandle,
+    ]);
   }
 
   handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>) {
@@ -169,9 +175,14 @@ export class RotateMode extends GeoJsonEditMode {
     const centroid = turfCentroid(this._geometryBeingRotated);
     const angle = getRotationAngle(centroid, startDragPoint, currentPoint);
     // @ts-ignore
-    const rotatedFeatures: FeatureCollection = turfTransformRotate(this._geometryBeingRotated, angle, {
-      pivot: centroid,
-    });
+    const rotatedFeatures: FeatureCollection = turfTransformRotate(
+      // @ts-ignore
+      this._geometryBeingRotated,
+      angle,
+      {
+        pivot: centroid,
+      }
+    );
 
     let updatedData = new ImmutableFeatureCollection(props.data);
 

--- a/modules/edit-modes/src/lib/scale-mode.ts
+++ b/modules/edit-modes/src/lib/scale-mode.ts
@@ -88,9 +88,12 @@ export class ScaleMode extends GeoJsonEditMode {
     // @ts-ignore
     const scaleFactor = getScaleFactor(origin, startDragPoint, currentPoint);
     // @ts-ignore
-    const scaledFeatures: FeatureCollection = turfTransformScale(this._geometryBeingScaled, scaleFactor, {
-      origin,
-    });
+    const scaledFeatures: FeatureCollection = turfTransformScale(
+      // @ts-ignore
+      this._geometryBeingScaled,
+      scaleFactor,
+      { origin }
+    );
 
     return {
       updatedData: this._getUpdatedData(props, scaledFeatures),


### PR DESCRIPTION
This [diff](https://github.com/visgl/deck.gl/commit/4ae30feaa52f3174bc72ab4dfb1a880840506ee1) released in deck.gl 8.1.3 changes the way deck behaves with picking occluding features. As a result, the translate portion of transform mode wouldn't work with later deck.gl versions because the scale/rotate bounding box guide occludes the underlying feature. To address this issue, I convert the bounding box guide into a linestring guide, thus resolving the occlusion issue.

Before diff:
![Screen Shot 2020-09-22 at 1 48 46 AM](https://user-images.githubusercontent.com/42187119/93861715-d26db600-fc75-11ea-99d2-6183953ce631.png)

After diff:
![Screen Shot 2020-09-22 at 1 49 00 AM](https://user-images.githubusercontent.com/42187119/93861724-d7326a00-fc75-11ea-8cd2-93f6b43d3d28.png)

Additionally, I figured that having rotate and scale edit handles on a single selected point feature is pointless, so I decided to remove that as well.

Before diff:
![Screen Shot 2020-09-22 at 1 49 50 AM](https://user-images.githubusercontent.com/42187119/93861801-f4ffcf00-fc75-11ea-9785-31b2d3e9e6ef.png)

After diff:
![Screen Shot 2020-09-22 at 1 50 02 AM](https://user-images.githubusercontent.com/42187119/93861817-faf5b000-fc75-11ea-9110-b05e107e1087.png)

Finally, I fixed an issue with rotate mode's cursor, where the cursor was continuously being calculated even while the user is dragging. This makes it possible for the cursor to change from `nesw-resize` to `nwse-resize` (or vice versa) in the midst of editing:

The bug (before diff):
![cursor_bug](https://user-images.githubusercontent.com/42187119/93862392-d51cdb00-fc76-11ea-9c26-20348b59a9f2.gif)

After diff:
![cursor_fix](https://user-images.githubusercontent.com/42187119/93862479-f978b780-fc76-11ea-940d-52d5a45ca2ae.gif)
