### PR TITLE
fix: issue with updateState when autoHighlight and pickable on

### DIFF
--- a/modules/layers/src/layers/editable-geojson-layer.ts
+++ b/modules/layers/src/layers/editable-geojson-layer.ts
@@ -286,7 +286,7 @@ export default class EditableGeoJsonLayer extends EditableLayer {
     changeFlags: any;
   }) {
     // @ts-ignore
-    super.updateState({ props, changeFlags });
+    super.updateState({ oldProps, props, changeFlags });
 
     if (changeFlags.propsOrDataChanged) {
       const modePropChanged = Object.keys(oldProps).length === 0 || props.mode !== oldProps.mode;


### PR DESCRIPTION
Layer doesn't seem to support calling `updateState` without oldProps because of this access: https://github.com/visgl/deck.gl/blob/1454a7cbae08b8d9b8e91e0bca1f52077e5e7918/modules/core/src/lib/layer.js#L331

![Screen Shot 2020-10-14 at 1 53 22 PM](https://user-images.githubusercontent.com/425716/96044026-a41e6900-0e24-11eb-8ff9-6c254dae244b.png)

Let me know if I missed the reason why oldProps isn't being passed in - if there is a purpose behind leaving it out then this should be fixed in deck.gl to make updateState work without oldProps.