### PR TITLE
Add missing @turf/helpers depenedency to overlays module

### DIFF
--- a/modules/overlays/package.json
+++ b/modules/overlays/package.json
@@ -49,6 +49,7 @@
     "test-rendering": "(cd test/rendering-test && webpack-dev-server --config webpack.config.test-rendering.js --progress --hot --open)"
   },
   "dependencies": {
+    "@turf/helpers": ">=4.0.0",
     "@types/supercluster": "5.0.2",
     "supercluster": "^6.0.1"
   },


### PR DESCRIPTION
Apparently the overlays module has been using `@turf/helpers` without it being declared in `package.json`:
https://github.com/uber/nebula.gl/blob/master/modules/overlays/src/html-cluster-overlay.ts#L1