### PR TITLE
Fix: add support for DrawPolygonByDragging mode

### DIFF
--- a/modules/react-map-gl-draw/src/index.ts
+++ b/modules/react-map-gl-draw/src/index.ts
@@ -13,4 +13,5 @@ export {
   DrawLineStringMode,
   DrawPolygonMode,
   DrawRectangleMode,
+  DrawPolygonByDraggingMode,
 } from '@nebula.gl/edit-modes';

--- a/modules/react-map-gl-draw/src/mode-handler.tsx
+++ b/modules/react-map-gl-draw/src/mode-handler.tsx
@@ -339,11 +339,16 @@ export default class ModeHandler extends React.PureComponent<EditorProps, Editor
       pointerDownPicks,
       pointerDownScreenCoords,
       pointerDownMapCoords,
+      cancelPan: event.sourceEvent.stopImmediatePropagation,
     };
 
     if (this.state.didDrag) {
       const modeProps = this.getModeProps();
-      this._modeHandler.handlePointerMove(pointerMoveEvent, modeProps);
+      if (this._modeHandler.handleDragging) {
+        this._modeHandler.handleDragging(pointerMoveEvent, modeProps);
+      } else {
+        this._modeHandler.handlePointerMove(pointerMoveEvent, modeProps);
+      }
     }
 
     this.setState({


### PR DESCRIPTION
Add support for `DrawPolygonByDragging` mode in `react-map-gl-draw`. 

**Example**
![Jan-20-2021 02-54-02](https://user-images.githubusercontent.com/13279201/105144188-dc3fe280-5aca-11eb-8957-5e979086a5e6.gif)
