### PR TITLE
Add resize circle mode

### DIFF
--- a/docs/api-reference/modes/overview.md
+++ b/docs/api-reference/modes/overview.md
@@ -73,6 +73,10 @@ The following options can be provided in the `modeConfig` object:
 
 - `position` (Array): An array containing the ground coordinates (i.e. [lng, lat]) of the added position
 
+## [ResizeCircleMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/resize-circle-mode.js)
+
+User can resize an existing circular Polygon feature by clicking and dragging along the ring.
+
 ## [DrawPolygonMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/draw-polygon-mode.js)
 
 User can draw a new `Polygon` feature by clicking positions to add then closing the polygon (or double-clicking).

--- a/examples/advanced/src/example.tsx
+++ b/examples/advanced/src/example.tsx
@@ -12,6 +12,7 @@ import {
   EditableGeoJsonLayer,
   SelectionLayer,
   ModifyMode,
+  ResizeCircleMode,
   TranslateMode,
   TransformMode,
   ScaleMode,
@@ -110,6 +111,7 @@ const ALL_MODES: any = [
     category: 'Alter',
     modes: [
       { label: 'Modify', mode: ModifyMode },
+      { label: 'Resize Circle', mode: ResizeCircleMode },
       { label: 'Elevation', mode: ElevationMode },
       { label: 'Translate', mode: new SnappableMode(new TranslateMode()) },
       { label: 'Rotate', mode: RotateMode },

--- a/modules/edit-modes/src/index.ts
+++ b/modules/edit-modes/src/index.ts
@@ -6,6 +6,7 @@ export { GeoJsonEditMode } from './lib/geojson-edit-mode';
 
 // Alter modes
 export { ModifyMode } from './lib/modify-mode';
+export { ResizeCircleMode } from './lib/resize-circle-mode';
 export { TranslateMode } from './lib/translate-mode';
 export { ScaleMode } from './lib/scale-mode';
 export { RotateMode } from './lib/rotate-mode';

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -25,16 +25,18 @@ import { ImmutableFeatureCollection } from './immutable-feature-collection';
 export class ResizeCircleMode extends GeoJsonEditMode {
   getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
     const handles = [];
+    const selectedFeatureIndexes = props.selectedIndexes;
 
     const { lastPointerMoveEvent } = props;
     const picks = lastPointerMoveEvent && lastPointerMoveEvent.picks;
     const mapCoords = lastPointerMoveEvent && lastPointerMoveEvent.mapCoords;
 
     // intermediate edit handle
-    if (picks && picks.length && mapCoords) {
+    if (picks && picks.length && mapCoords && selectedFeatureIndexes.length === 1) {
       const existingEditHandle = getPickedExistingEditHandle(picks);
       // don't show intermediate point when too close to an existing edit handle
       const featureAsPick = !existingEditHandle && picks.find((pick) => !pick.isGuide);
+      console.log(featureAsPick);
 
       // is the feature in the pick selected
       if (

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -8,7 +8,6 @@ import {
   nearestPointOnProjectedLine,
   getPickedEditHandles,
   getPickedEditHandle,
-  getPickedExistingEditHandle,
   NearestPointType,
 } from '../utils';
 import { LineString, Point, FeatureCollection, FeatureOf } from '../geojson-types';
@@ -33,9 +32,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
 
     // intermediate edit handle
     if (picks && picks.length && mapCoords && selectedFeatureIndexes.length === 1) {
-      const existingEditHandle = getPickedExistingEditHandle(picks);
-      // don't show intermediate point when too close to an existing edit handle
-      const featureAsPick = !existingEditHandle && picks.find((pick) => !pick.isGuide);
+      const featureAsPick = picks.find((pick) => !pick.isGuide);
 
       // is the feature in the pick selected
       if (

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -39,7 +39,8 @@ export class ResizeCircleMode extends GeoJsonEditMode {
       // is the feature in the pick selected
       if (
         featureAsPick &&
-        !featureAsPick.object.geometry.type.includes('Point') &&
+        featureAsPick.object.properties.shape &&
+        featureAsPick.object.properties.shape.includes('Circle') &&
         props.selectedIndexes.includes(featureAsPick.index)
       ) {
         let intermediatePoint: NearestPointType | null | undefined = null;

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -132,8 +132,8 @@ export class ResizeCircleMode extends GeoJsonEditMode {
 
       const { steps = 64 } = {};
       const options = { steps };
-      const updateFeature = circle(center, radius, options);
-      const geometry = updateFeature.geometry;
+      const updatedFeature = circle(center, radius, options);
+      const geometry = updatedFeature.geometry;
 
       const updatedData = new ImmutableFeatureCollection(props.data)
         .replaceGeometry(

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -36,7 +36,6 @@ export class ResizeCircleMode extends GeoJsonEditMode {
       const existingEditHandle = getPickedExistingEditHandle(picks);
       // don't show intermediate point when too close to an existing edit handle
       const featureAsPick = !existingEditHandle && picks.find((pick) => !pick.isGuide);
-      console.log(featureAsPick);
 
       // is the feature in the pick selected
       if (

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -135,10 +135,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
       const geometry = updatedFeature.geometry;
 
       const updatedData = new ImmutableFeatureCollection(props.data)
-        .replaceGeometry(
-          editHandleProperties.featureIndex,
-          geometry
-        )
+        .replaceGeometry(editHandleProperties.featureIndex, geometry)
         .getObject();
 
       props.onEdit({

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -1,0 +1,169 @@
+import nearestPointOnLine from '@turf/nearest-point-on-line';
+import { point, lineString as toLineString } from '@turf/helpers';
+import circle from '@turf/circle';
+import distance from '@turf/distance';
+import turfCenter from '@turf/center';
+import {
+  recursivelyTraverseNestedArrays,
+  nearestPointOnProjectedLine,
+  getPickedEditHandles,
+  getPickedEditHandle,
+  getPickedExistingEditHandle,
+  NearestPointType,
+} from '../utils';
+import { LineString, Point, FeatureCollection, FeatureOf } from '../geojson-types';
+import {
+  ModeProps,
+  PointerMoveEvent,
+  DraggingEvent,
+  Viewport,
+  GuideFeatureCollection,
+} from '../types';
+import { GeoJsonEditMode } from './geojson-edit-mode';
+import { ImmutableFeatureCollection } from './immutable-feature-collection';
+
+export class ResizeCircleMode extends GeoJsonEditMode {
+  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
+    const handles = [];
+
+    const { lastPointerMoveEvent } = props;
+    const picks = lastPointerMoveEvent && lastPointerMoveEvent.picks;
+    const mapCoords = lastPointerMoveEvent && lastPointerMoveEvent.mapCoords;
+
+    // intermediate edit handle
+    if (picks && picks.length && mapCoords) {
+      const existingEditHandle = getPickedExistingEditHandle(picks);
+      // don't show intermediate point when too close to an existing edit handle
+      const featureAsPick = !existingEditHandle && picks.find((pick) => !pick.isGuide);
+
+      // is the feature in the pick selected
+      if (
+        featureAsPick &&
+        !featureAsPick.object.geometry.type.includes('Point') &&
+        props.selectedIndexes.includes(featureAsPick.index)
+      ) {
+        let intermediatePoint: NearestPointType | null | undefined = null;
+        let positionIndexPrefix = [];
+        const referencePoint = point(mapCoords);
+        // process all lines of the (single) feature
+        recursivelyTraverseNestedArrays(
+          featureAsPick.object.geometry.coordinates,
+          [],
+          (lineString, prefix) => {
+            const lineStringFeature = toLineString(lineString);
+            const candidateIntermediatePoint = this.nearestPointOnLine(
+              // @ts-ignore
+              lineStringFeature,
+              referencePoint,
+              props.modeConfig && props.modeConfig.viewport
+            );
+            if (
+              !intermediatePoint ||
+              candidateIntermediatePoint.properties.dist < intermediatePoint.properties.dist
+            ) {
+              intermediatePoint = candidateIntermediatePoint;
+              positionIndexPrefix = prefix;
+            }
+          }
+        );
+        // tack on the lone intermediate point to the set of handles
+        if (intermediatePoint) {
+          const {
+            geometry: { coordinates: position },
+            properties: { index },
+          } = intermediatePoint;
+          handles.push({
+            type: 'Feature',
+            properties: {
+              guideType: 'editHandle',
+              editHandleType: 'intermediate',
+              featureIndex: featureAsPick.index,
+              positionIndexes: [...positionIndexPrefix, index + 1],
+            },
+            geometry: {
+              type: 'Point',
+              coordinates: position,
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      type: 'FeatureCollection',
+      features: handles,
+    };
+  }
+
+  // turf.js does not support elevation for nearestPointOnLine
+  nearestPointOnLine(
+    line: FeatureOf<LineString>,
+    inPoint: FeatureOf<Point>,
+    viewport: Viewport | null | undefined
+  ): NearestPointType {
+    const { coordinates } = line.geometry;
+    if (coordinates.some((coord) => coord.length > 2)) {
+      if (viewport) {
+        // This line has elevation, we need to use alternative algorithm
+        return nearestPointOnProjectedLine(line, inPoint, viewport);
+      }
+      // eslint-disable-next-line no-console,no-undef
+      console.log(
+        'Editing 3D point but modeConfig.viewport not provided. Falling back to 2D logic.'
+      );
+    }
+
+    return nearestPointOnLine(line, inPoint);
+  }
+
+  handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>): void {
+    const editHandle = getPickedEditHandle(event.pointerDownPicks);
+
+    if (editHandle) {
+      // Cancel map panning if pointer went down on an edit handle
+      event.cancelPan();
+
+      const editHandleProperties = editHandle.properties;
+
+      const feature = this.getSelectedFeature(props);
+      const center = turfCenter(feature).geometry.coordinates;
+
+      const radius = Math.max(distance(center, event.mapCoords), 0.001);
+
+      const { steps = 64 } = {};
+      const options = { steps };
+      const updateFeature = circle(center, radius, options);
+      const geometry = updateFeature.geometry;
+
+      const updatedData = new ImmutableFeatureCollection(props.data)
+        .replaceGeometry(
+          editHandleProperties.featureIndex,
+          geometry
+        )
+        .getObject();
+
+      props.onEdit({
+        updatedData,
+        editType: 'unionGeometry',
+        editContext: {
+          featureIndexes: [editHandleProperties.featureIndex],
+        },
+      });
+    }
+  }
+
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+    const cursor = this.getCursor(event);
+    props.onUpdateCursor(cursor);
+  }
+
+  getCursor(event: PointerMoveEvent): string | null | undefined {
+    const picks = (event && event.picks) || [];
+
+    const handlesPicked = getPickedEditHandles(picks);
+    if (handlesPicked.length) {
+      return 'cell';
+    }
+    return null;
+  }
+}

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -128,10 +128,10 @@ export class ResizeCircleMode extends GeoJsonEditMode {
 
       const feature = this.getSelectedFeature(props);
       const center = turfCenter(feature).geometry.coordinates;
-
+      const numberOfSteps = Object.entries(feature.geometry.coordinates[0]).length - 1;
       const radius = Math.max(distance(center, event.mapCoords), 0.001);
 
-      const { steps = 64 } = {};
+      const { steps = numberOfSteps } = {};
       const options = { steps };
       const updatedFeature = circle(center, radius, options);
       const geometry = updatedFeature.geometry;

--- a/modules/main/src/index.ts
+++ b/modules/main/src/index.ts
@@ -29,6 +29,7 @@ export { GeoJsonEditMode } from '@nebula.gl/edit-modes';
 
 // Alter modes
 export { ModifyMode } from '@nebula.gl/edit-modes';
+export { ResizeCircleMode } from '@nebula.gl/edit-modes';
 export { TranslateMode } from '@nebula.gl/edit-modes';
 export { ScaleMode } from '@nebula.gl/edit-modes';
 export { RotateMode } from '@nebula.gl/edit-modes';


### PR DESCRIPTION
Added edit mode to resize an existing circular Polygon feature.

How it works: 
- Select a circular Polygon feature,
- Click + hold and drag away from the center to increase the size of the feature,
- Click + hold and drag inward to decrease the size of feature

Example
![resize-circle-mode](https://user-images.githubusercontent.com/26821509/107155930-9d8ba280-697b-11eb-957c-a634d2e13049.gif)
