### PR TITLE
Fix cursor issue when using the scale mode

### DIFF
--- a/modules/edit-modes/src/lib/scale-mode.ts
+++ b/modules/edit-modes/src/lib/scale-mode.ts
@@ -139,9 +139,7 @@ export class ScaleMode extends GeoJsonEditMode {
           ? selectedEditHandle
           : null;
 
-      if (selectedEditHandle) {
-        this.updateCursor(props);
-      }
+      this.updateCursor(props);
     }
   }
 


### PR DESCRIPTION
When the scale edit mode is enabled, the bidirectional resize cursor icon (nesw-resize or nwse-resize) should only be visible in the following cases:
1) when hovering above one of the handles
2) when scaling one or more features

Currently it remains visible after hovering once above one of the handles (even when not hovering or scaling).

Before (cursor not ok)
![scaling-before](https://user-images.githubusercontent.com/26821509/108397624-6f7a4e00-7218-11eb-832c-15e4c17f7aa0.png)

After (cursor ok)
![scaling-after](https://user-images.githubusercontent.com/26821509/108397647-76a15c00-7218-11eb-8a23-634158deb63e.png)

