### PR TITLE
Add ability to resize an existing circle by clicking twice

### DIFF
--- a/docs/api-reference/modes/overview.md
+++ b/docs/api-reference/modes/overview.md
@@ -75,7 +75,14 @@ The following options can be provided in the `modeConfig` object:
 
 ## [ResizeCircleMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/resize-circle-mode.js)
 
-User can resize an existing circular Polygon feature by clicking and dragging along the ring.
+User can resize an existing circular Polygon feature by clicking along the ring.
+
+### ModeConfig
+
+The following options can be provided in the `modeConfig` object:
+
+- `dragToDraw` (optional): `boolean`
+  - If `true`, user can click and drag instead of clicking twice. Note however, that the user will not be able to pan the map while drawing.
 
 ## [DrawPolygonMode](https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/lib/draw-polygon-mode.js)
 

--- a/examples/advanced/src/example.tsx
+++ b/examples/advanced/src/example.tsx
@@ -606,6 +606,9 @@ export default class Example extends React.Component<
     if (this.state.mode === MeasureDistanceMode) {
       controls.push(this._renderMeasureDistanceControls());
     }
+    if (this.state.mode === ResizeCircleMode) {
+      controls.push(this._renderTwoClickPolygonControls());
+    }
 
     return controls;
   }

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -10,8 +10,9 @@ import {
   getPickedEditHandle,
   NearestPointType,
 } from '../utils';
-import { LineString, Point, FeatureCollection, FeatureOf } from '../geojson-types';
+import { LineString, Point, Position, FeatureCollection, FeatureOf } from '../geojson-types';
 import {
+  ClickEvent,
   ModeProps,
   PointerMoveEvent,
   StartDraggingEvent,
@@ -128,6 +129,10 @@ export class ResizeCircleMode extends GeoJsonEditMode {
   }
 
   handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>): void {
+    if (props.modeConfig && !props.modeConfig.dragToDraw) {
+      return;
+    }
+
     const editHandle = getPickedEditHandle(event.pointerDownPicks);
 
     if (editHandle) {
@@ -135,32 +140,35 @@ export class ResizeCircleMode extends GeoJsonEditMode {
       event.cancelPan();
 
       const editHandleProperties = editHandle.properties;
+      const featureIndex = editHandleProperties.featureIndex;
+      const pointerPosition = event.mapCoords;
+      this.drawCircle(featureIndex, pointerPosition, props);
+    }
+  }
 
-      const feature = this.getSelectedFeature(props);
-      const center = turfCenter(feature).geometry.coordinates;
-      const numberOfSteps = Object.entries(feature.geometry.coordinates[0]).length - 1;
-      const radius = Math.max(distance(center, event.mapCoords), 0.001);
+  handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {
+    if (props.modeConfig && props.modeConfig.dragToDraw) {
+      // handled in drag handlers
+      return;
+    }
 
-      const { steps = numberOfSteps } = {};
-      const options = { steps };
-      const updatedFeature = circle(center, radius, options);
-      const geometry = updatedFeature.geometry;
-
-      const updatedData = new ImmutableFeatureCollection(props.data)
-        .replaceGeometry(editHandleProperties.featureIndex, geometry)
-        .getObject();
-
-      props.onEdit({
-        updatedData,
-        editType: 'unionGeometry',
-        editContext: {
-          featureIndexes: [editHandleProperties.featureIndex],
-        },
-      });
+    this.addClickSequence(event);
+    const clickSequence = this.getClickSequence();
+    if (clickSequence.length > 1) {
+      this._isResizing = false;
+      this.resetClickSequence();
+    } else {
+      this._isResizing = true;
     }
   }
 
   handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>): void {
+    if (props.modeConfig && !props.modeConfig.dragToDraw && this._isResizing) {
+      const featureIndex = props.selectedIndexes[0];
+      const pointerPosition = event.mapCoords;
+      this.drawCircle(featureIndex, pointerPosition, props);
+    }
+
     if (!this._isResizing) {
       const selectedEditHandle = getPickedEditHandle(event.picks);
       this._selectedEditHandle =
@@ -174,13 +182,13 @@ export class ResizeCircleMode extends GeoJsonEditMode {
   }
 
   handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
-    if (this._selectedEditHandle) {
+    if (props.modeConfig && props.modeConfig.dragToDraw && this._selectedEditHandle) {
       this._isResizing = true;
     }
   }
 
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
-    if (this._isResizing) {
+    if (props.modeConfig && props.modeConfig.dragToDraw && this._isResizing) {
       this._selectedEditHandle = null;
       this._isResizing = false;
     }
@@ -194,5 +202,29 @@ export class ResizeCircleMode extends GeoJsonEditMode {
       return 'cell';
     }
     return null;
+  }
+
+  drawCircle(featureIndex: number, pointerPosition: Position, props: ModeProps<FeatureCollection>) {
+    const feature = this.getSelectedFeature(props);
+    const center = turfCenter(feature).geometry.coordinates;
+    const numberOfSteps = Object.entries(feature.geometry.coordinates[0]).length - 1;
+    const radius = Math.max(distance(center, pointerPosition), 0.001);
+
+    const { steps = numberOfSteps } = {};
+    const options = { steps };
+    const updatedFeature = circle(center, radius, options);
+    const geometry = updatedFeature.geometry;
+
+    const updatedData = new ImmutableFeatureCollection(props.data)
+      .replaceGeometry(featureIndex, geometry)
+      .getObject();
+
+    props.onEdit({
+      updatedData,
+      editType: 'unionGeometry',
+      editContext: {
+        featureIndexes: [featureIndex],
+      },
+    });
   }
 }


### PR DESCRIPTION
By default a circle can now be resized by clicking twice along the ring.
The 'dragToDraw' option has been added to the mode config to enable dragging instead of clicking twice.