### PR TITLE
[path-marker-layer] Fix arrow direction for deck.gl version > 8.0

### DIFF
--- a/modules/layers/src/layers/path-marker-layer/create-path-markers.ts
+++ b/modules/layers/src/layers/path-marker-layer/create-path-markers.ts
@@ -86,7 +86,7 @@ function createMarkerAlongPath({ path, percentage, lineLength, color, object, pr
   const vCenter = vDirection.clone().multiply(new Vector2(along, along)).add(path[i]);
 
   const vDirection2 = new Vector2(projectFlat(path[i + 1])).subtract(projectFlat(path[i]));
-  const angle = (-vDirection2.verticalAngle() * 180) / Math.PI;
+  const angle = 180 + (vDirection2.verticalAngle() * 180) / Math.PI;
 
   return { position: [vCenter.x, vCenter.y, 0], angle, color, object };
 }


### PR DESCRIPTION
`PathMarkerLayer` was broken for deck.gl version > 8.0: 

- Arrow direction was incorrect

before the fix:

<img width="850" alt="before" src="https://user-images.githubusercontent.com/1288382/108395088-4632d100-71ca-11eb-9319-7c900ac2b057.png">

after fix:

<img width="818" alt="after" src="https://user-images.githubusercontent.com/1288382/108395112-4df27580-71ca-11eb-9be6-6515e8e339ed.png">

