### PR TITLE
Fix for destructuring optional properties

### DIFF
--- a/modules/react-map-gl-draw/src/editor.tsx
+++ b/modules/react-map-gl-draw/src/editor.tsx
@@ -279,8 +279,10 @@ export default class Editor extends ModeHandler {
     const { featureStyle } = this.props;
     const {
       geometry: { type: geojsonType },
-      properties: { shape },
+      properties,
     } = feature;
+
+    const shape = properties?.shape;
 
     const coordinates = getFeatureCoordinates(feature);
     if (!coordinates || !Array.isArray(coordinates) || coordinates.length < 2) {
@@ -545,9 +547,11 @@ export default class Editor extends ModeHandler {
       return null;
     }
     const {
-      properties: { shape },
+      properties,
       geometry: { type: geojsonType },
     } = feature;
+
+    const shape = properties?.shape;
     // @ts-ignore
     const path = this._getPathInScreenCoords(coordinates, geojsonType);
     if (!path) {


### PR DESCRIPTION
The property `properties` is optional (https://github.com/uber/nebula.gl/blob/master/modules/edit-modes/src/geojson-types.ts#L60) and therefore breaks if any of the `features` don't have a `properties` value. This is because we try to destructure `properties` to get the `shape` value.

Error:
<img width="611" alt="Screenshot 2021-03-18 at 20 53 53" src="https://user-images.githubusercontent.com/9355016/111701553-ec5a1100-8832-11eb-8366-16e963f84b3e.png">

I have verified this fix locally and and everything works as expected 😄 

See this issue -> https://github.com/uber/nebula.gl/issues/545