### PR TITLE
Add option to prevent overlapping lines when drawing a polygon

### DIFF
--- a/docs/api-reference/modes/overview.md
+++ b/docs/api-reference/modes/overview.md
@@ -81,6 +81,13 @@ User can resize an existing circular Polygon feature by clicking and dragging al
 
 User can draw a new `Polygon` feature by clicking positions to add then closing the polygon (or double-clicking).
 
+### ModeConfig
+
+The following options can be provided in the `modeConfig` object:
+
+- `preventOverlappingLines` (optional): `boolean`
+  - If `true`, it will not be possible to add a polygon point if the current line overlaps any other lines on the same polygon.
+
 ### Edit Context
 
 `editContext` argument to the `onEdit` callback contains the following properties:

--- a/examples/advanced/src/example.tsx
+++ b/examples/advanced/src/example.tsx
@@ -342,7 +342,9 @@ export default class Example extends React.Component<
   };
 
   _download = () => {
-    const blob = new Blob([JSON.stringify(this.state.testFeatures)], { type: 'octet/stream' });
+    const blob = new Blob([JSON.stringify(this.state.testFeatures)], {
+      type: 'octet/stream',
+    });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
     a.download = 'nebula.geojson';
@@ -464,11 +466,17 @@ export default class Example extends React.Component<
               onClick={() => {
                 if (this.state.modeConfig && this.state.modeConfig.booleanOperation === operation) {
                   this.setState({
-                    modeConfig: { ...(this.state.modeConfig || {}), booleanOperation: null },
+                    modeConfig: {
+                      ...(this.state.modeConfig || {}),
+                      booleanOperation: null,
+                    },
                   });
                 } else {
                   this.setState({
-                    modeConfig: { ...(this.state.modeConfig || {}), booleanOperation: operation },
+                    modeConfig: {
+                      ...(this.state.modeConfig || {}),
+                      booleanOperation: operation,
+                    },
                   });
                 }
               }}
@@ -527,7 +535,9 @@ export default class Example extends React.Component<
             type="checkbox"
             checked={Boolean(this.state.modeConfig && this.state.modeConfig.lock90Degree)}
             onChange={(event) =>
-              this.setState({ modeConfig: { lock90Degree: Boolean(event.target.checked) } })
+              this.setState({
+                modeConfig: { lock90Degree: Boolean(event.target.checked) },
+              })
             }
           />
         </ToolboxControl>
@@ -588,6 +598,30 @@ export default class Example extends React.Component<
     );
   }
 
+  _renderDrawPolygonModeControls() {
+    return (
+      <ToolboxRow key="draw-polygon">
+        <ToolboxTitle>Prevent overlapping lines</ToolboxTitle>
+        <ToolboxControl>
+          <input
+            type="checkbox"
+            checked={Boolean(
+              this.state.modeConfig && this.state.modeConfig.preventOverlappingLines
+            )}
+            onChange={(event) =>
+              this.setState({
+                modeConfig: {
+                  ...(this.state.modeConfig || {}),
+                  preventOverlappingLines: Boolean(event.target.checked),
+                },
+              })
+            }
+          />
+        </ToolboxControl>
+      </ToolboxRow>
+    );
+  }
+
   _renderModeConfigControls() {
     const controls = [];
 
@@ -609,6 +643,9 @@ export default class Example extends React.Component<
     }
     if (this.state.mode === MeasureDistanceMode) {
       controls.push(this._renderMeasureDistanceControls());
+    }
+    if (this.state.mode === DrawPolygonMode) {
+      controls.push(this._renderDrawPolygonModeControls());
     }
 
     return controls;
@@ -726,21 +763,30 @@ export default class Example extends React.Component<
           <ToolboxControl>
             <ToolboxButton
               onClick={() =>
-                this.setState({ selectedFeatureIndexes: [], selectionTool: SELECTION_TYPE.NONE })
+                this.setState({
+                  selectedFeatureIndexes: [],
+                  selectionTool: SELECTION_TYPE.NONE,
+                })
               }
             >
               Clear Selection
             </ToolboxButton>
             <ToolboxButton
               onClick={() =>
-                this.setState({ mode: ViewMode, selectionTool: SELECTION_TYPE.RECTANGLE })
+                this.setState({
+                  mode: ViewMode,
+                  selectionTool: SELECTION_TYPE.RECTANGLE,
+                })
               }
             >
               Rect Select
             </ToolboxButton>
             <ToolboxButton
               onClick={() =>
-                this.setState({ mode: ViewMode, selectionTool: SELECTION_TYPE.POLYGON })
+                this.setState({
+                  mode: ViewMode,
+                  selectionTool: SELECTION_TYPE.POLYGON,
+                })
               }
             >
               Lasso Select
@@ -1009,7 +1055,9 @@ export default class Example extends React.Component<
           // @ts-ignore
           selectionType: this.state.selectionTool,
           onSelect: ({ pickingInfos }) => {
-            this.setState({ selectedFeatureIndexes: pickingInfos.map((pi) => pi.index) });
+            this.setState({
+              selectedFeatureIndexes: pickingInfos.map((pi) => pi.index),
+            });
           },
           layerIds: ['geojson'],
 

--- a/modules/edit-modes/src/lib/draw-polygon-mode.ts
+++ b/modules/edit-modes/src/lib/draw-polygon-mode.ts
@@ -84,7 +84,7 @@ export class DrawPolygonMode extends GeoJsonEditMode {
     const clickSequence = this.getClickSequence();
 
     let currentLineOverlapsOtherLines = false;
-    if (clickSequence.length > 2) {
+    if (clickSequence.length > 2 && props.modeConfig && props.modeConfig.preventOverlappingLines) {
       const line1 = turfLineString([clickSequence[clickSequence.length - 1], event.mapCoords]);
       const line2 = turfLineString([...clickSequence.slice(0, clickSequence.length - 1)]);
       const intersectingPoints = lineIntersect(line1, line2);


### PR DESCRIPTION
Adds the 'preventOverlappingLines' mode config option to the 'draw polygon' edit mode.
When true, adding a polygon point will be prevented if the current line overlaps any other lines on the same polygon.

Note: no feedback message is shown when it's not possible to add a polygon point.

Demo
![draw-polygon-without-overlapping-lines](https://user-images.githubusercontent.com/26821509/113489233-57f2de00-94c3-11eb-8e82-e12bdb6e3992.gif)
