### PR TITLE
added circleResizeEnd onEdit callback no notify when dragging ended. …

### DIFF
--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -152,7 +152,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
 
       props.onEdit({
         updatedData,
-        editType: 'unionGeometry',
+        editType: 'circleResize',
         editContext: {
           featureIndexes: [editHandleProperties.featureIndex],
         },
@@ -181,6 +181,14 @@ export class ResizeCircleMode extends GeoJsonEditMode {
 
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
     if (this._isResizing) {
+      props.onEdit({
+        updatedData: props.data,
+        editType: 'circleResizeEnd',
+        editContext: {
+          featureIndexes: props.selectedIndexes,
+        },
+      });
+
       this._selectedEditHandle = null;
       this._isResizing = false;
     }


### PR DESCRIPTION
Changed circle resize onEdit callback to have unique editType during resize. Also added onEdit callback to notify when dragging has ended. Issue this resolves: [535](https://github.com/uber/nebula.gl/issues/535)