### PR TITLE
Update EditableGeoJSONLayer docs and update outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 [![docs](https://i.imgur.com/bRDL1oh.gif)](https://nebula.gl)
 
-[nebula.gl](https://nebula.gl) provides editable and interactive map overlay layers, built using the power of [deck.gl](https://uber.github.io/deck.gl).
+[nebula.gl](https://nebula.gl) provides editable and interactive map overlay layers, built using the power of [deck.gl](https://deck.gl/).
 
 ## Getting started
 
@@ -52,7 +52,19 @@
 
 ### Installation
 
+For npm
+
+```bash
+npm install @nebula.gl/layers
+npm install @nebula.gl/overlays
+npm install @deck.gl/core
+npm install @deck.gl/react
+npm install @deck.gl/layers
 ```
+
+For yarn
+
+```bash
 yarn add @nebula.gl/layers
 yarn add @nebula.gl/overlays
 yarn add @deck.gl/core
@@ -64,7 +76,7 @@ yarn add @deck.gl/layers
 
 [EditableGeoJsonLayer](/docs/api-reference/layers/editable-geojson-layer.md) is implemented as a [deck.gl](https://deck.gl) layer. It provides the ability to view and edit multiple types of geometry formatted as [GeoJSON](https://tools.ietf.org/html/rfc7946) (an open standard format for geometry) including polygons, lines, and points.
 
-```js
+```jsx
 import DeckGL from '@deck.gl/react';
 import { EditableGeoJsonLayer, DrawPolygonMode } from 'nebula.gl';
 
@@ -103,7 +115,7 @@ class App extends React.Component {
 
 ### Useful examples (Codesandbox)
 
-* [Hello World (using deck.gl)](https://codesandbox.io/s/hello-world-nebulagl-csvsm)
-* [With Toolbox](https://codesandbox.io/s/hello-nebulagl-with-toolbox-oelkr)
-* [No React](https://codesandbox.io/s/deckgl-and-nebulagl-editablegeojsonlayer-no-react-p9yrs)
-* [Custom EditMode](https://codesandbox.io/s/connect-the-dots-mode-yow65)
+- [Hello World (using deck.gl)](https://codesandbox.io/s/hello-world-nebulagl-csvsm)
+- [With Toolbox](https://codesandbox.io/s/hello-nebulagl-with-toolbox-oelkr)
+- [No React](https://codesandbox.io/s/deckgl-and-nebulagl-editablegeojsonlayer-no-react-p9yrs)
+- [Custom EditMode](https://codesandbox.io/s/connect-the-dots-mode-yow65)

--- a/dev-docs/RFCs/v1.0/react-map-gl-draw.md
+++ b/dev-docs/RFCs/v1.0/react-map-gl-draw.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-[react-map-gl](https://uber.github.io/react-map-gl/) currently does not support drawing functions. However, we have got a couple of [users](https://github.com/uber/react-map-gl/issues/725) interested in this capability. Also it is one of P0 features on Kepler.gl 2019 [roadmap](https://github.com/uber/kepler.gl/wiki/Kepler.gl-2019-Roadmap#allow-drawing-on-map-to-create-paths-and-polygons--).
+[react-map-gl](https://visgl.github.io/react-map-gl/) currently does not support drawing functions. However, we have got a couple of [users](https://github.com/uber/react-map-gl/issues/725) interested in this capability. Also it is one of P0 features on Kepler.gl 2019 [roadmap](https://github.com/uber/kepler.gl/wiki/Kepler.gl-2019-Roadmap#allow-drawing-on-map-to-create-paths-and-polygons--).
 
 Although [Mapbox/mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw) provides drawing and editing features, because of its manipulating internal states, it cannot work well with React / Redux framework and therefore cannot be integrated with `react-map-gl`.
 Another `vis.gl` framework [Nebula.gl](http://nebula.gl) also provides geo editing functionality, but it heavily depends on [`deck.gl`](https://deck.gl/), which may not be suitable for non `deck.gl` use cases.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-[nebula.gl](https://nebula.gl) provides editable and interactive map overlay layers, built using the power of [deck.gl](https://uber.github.io/deck.gl).
+[nebula.gl](https://nebula.gl) provides editable and interactive map overlay layers, built using the power of [deck.gl](https://deck.gl/).
 
 ## Design Goals
 

--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -41,7 +41,9 @@ class App extends React.Component {
 
 ## Properties
 
-Inherits all [deck.gl's Base Layer](https://uber.github.io/deck.gl/#/documentation/deckgl-api-reference/layers/layer) properties.
+Inherits all [deck.gl's Base Layer](https://deck.gl/docs/api-reference/core/layer) properties.
+
+`EditableGeoJSONLayer` is a [CompositeLayer](https://deck.gl/docs/api-reference/core/composite-layer) of [GeoJSONLayer](https://deck.gl/docs/api-reference/layers/geojson-layer), [ScatterPlotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer), and [IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer). Many of the properties and data getters of those layers are aliased.
 
 #### `data` (Object, optional)
 
@@ -82,7 +84,7 @@ Snapping-related `modeConfig` properties:
 
 - Default: `[]`
 
-The `selectedFeatureIndexes` property distinguishes which features to treat as selected.
+The `selectedFeatureIndexes` property distinguishes which features to treat as selected. This property is required when using the `DrawPolygonMode` edit mode.
 
 - Features are identified by their index in the collection.
 
@@ -105,6 +107,8 @@ The `onEdit` event is the core event provided by this layer and must be handled 
   - You may also supply a modified version of this object into the `data` prop on the next render cycle (e.g. if you have your own snapping logic).
 
 - `editType` (String): The type of edit requested. One of:
+
+  - `updateTentativeFeature`: Fired whenever a feature is near completion, and user continued dragging the cursor mid-editing. It fires on pointer move for `DrawPointMode`. The tentative feature created is different for each mode.
 
   - `movePosition`: A position was moved.
 
@@ -133,14 +137,210 @@ The `onEdit` event is the core event provided by this layer and must be handled 
   - `startExtruding`: An edge started extruding (e.g. user started dragging).
 
   - `extruding`: An edge is extruding.
-
   - `extruded`: An edge finished extruding (e.g. user finished dragging).
 
   - `split`: A feature finished splitting.
 
-- `featureIndexes` (Array&lt;number&gt;): The indexes of the edited/added features.
+* `featureIndexes` (Array&lt;number&gt;): The indexes of the edited/added features.
 
-- `editContext` (Object): `null` or an object containing additional context about the edit. This is populated by the active mode, see [modes overview](../modes/overview.md).
+* `editContext` (Object): `null` or an object containing additional context about the edit. This is populated by the active mode, see [modes overview](../modes/overview.md).
+
+### Guide style properties and data getters
+
+#### `editHandleType`: (String, optional)
+
+- Default `point`
+
+Edit handles are points that are part of an existing geometry used for manipulation or snapping.
+
+- `existing`
+- `snap-source`
+- `snap-target`
+- `intermediate`
+- `existing`
+- `snap`
+
+See the 'Edit Handles' section below.
+
+#### `getTentativeLineColor` (Array|Function, optional)
+
+- Default: `[0, 0, 0, 255]`
+
+The line color for features that are being edited and are not yet finalized. See `getLineColor`in [DeckGl GeoJSONLayer](https://deck.gl/docs/api-reference/layers/geojson-layer).
+
+#### `getTentativeFillColor` (Array|Function, optional)
+
+- Default `[0, 0, 0, 255]`
+
+The fill color for features that are being edited and are not yet finalized. See `getFillColor`in [DeckGl GeoJSONLayer](https://deck.gl/docs/api-reference/layers/geojson-layer).
+
+#### `getTentativeLineWidth` (Function|Number, optional)
+
+- Default `3`
+
+The line width for features that are being edited and are not yet finalized, in units specified by lineWidthUnits (default meters). See `getLineWidth`in [DeckGl GeoJSONLayer](https://deck.gl/docs/api-reference/layers/geojson-layer).
+
+If a number is provided, it is used as the outline width for all objects.
+If a function is provided, it is called on each object to retrieve its outline width.
+If not provided, it falls back to strokeWidth.
+
+#### `editHandlePointRadiusScale`: (Function|Number, optional)
+
+- Default: `1`
+
+A global radius multiplier for all edit handle points. See `radiusScale` in [DeckGl ScatterplotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer).
+
+#### `editHandlePointOutline`: (Boolean|Function, optional)
+
+- Default: `true`
+
+Only draw outline of points. It falls back to outline if not provided. See `stroke` in [DeckGl ScatterplotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer).
+
+#### `editHandlePointStrokeWidth`: (Function|Number)
+
+- Default: `2`
+
+#### `editHandlePointRadiusMinPixels`: (Function|Number)
+
+- Default: `4`
+
+The minimum radius of the edit handle in pixels. This prop can be used to prevent the circle from getting too small when zoomed out. See `radiusMinPixels` in [DeckGl ScatterplotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer).
+
+#### `editHandlePointRadiusMaxPixels`: (Function|Number, optional)
+
+- Default: `8`
+
+The maximum radius of the edit handle in pixels. This prop can be used to prevent the circle from getting too big when zoomed in. See `radiusMaxPixels` in [DeckGl ScatterplotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer).
+
+#### `getEditHandlePointColor` (Array|Function, optional)
+
+- Default: `[0, 0, 0, 255]`
+
+The rgba color is in the format of `[r, g, b, [a]]`. Each channel is a number between 0-255 and `a` is 255 if not supplied.
+
+If an array is provided, it is used as the filled color for all objects.
+
+If a function is provided, it is called on each object to retrieve its color.
+
+See `getFillColor` in [DeckGl ScatterplotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer).
+
+#### `getEditHandlePointOutlineColor` (Array|Function, optional)
+
+- Default `[0, 0, 0, 255]`
+
+The outline color of the edit handle point. See in DeckGl
+
+The rgba color is in the format of `[r, g, b, [a]]`. Each channel is a number between 0-255 and `a` is 255 if not supplied.
+
+If an array is provided, it is used as the outline color for all objects.
+
+If a function is provided, it is called on each object to retrieve its color.
+
+See `getLineColor` in [DeckGl ScatterplotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer).
+
+#### `getEditHandlePointRadius` (Function|Number, optional)
+
+- Default: `1`
+
+The radius of each edit handle, in units specified by radiusUnits (default `meters`).
+
+If a number is provided, it is used as the radius for all objects.
+
+If a function is provided, it is called on each object to retrieve its radius.
+
+See `getRadius` in [DeckGl ScatterplotLayer](https://deck.gl/docs/api-reference/layers/scatterplot-layer).
+
+---
+
+#### `editHandleIconAtlas` (String|Texture2D|Image|ImageData|HTMLCanvasElement|HTMLVideoElement|ImageBitmap|Object, optional)
+
+Default: `null`
+
+See `iconAtlas`in [DeckGl IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer).
+
+#### `editHandleIconMapping` (Object|String, optional)
+
+The atlas image.
+
+If a string is supplied, it is interpreted as a URL or a Data URL.
+One of the valid pixel sources for WebGL texture
+A luma.gl Texture2D instance
+A plain object that can be passed to the Texture2D constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
+The image data will be converted to a Texture2D object. See textureParameters prop for advanced customization.
+
+If you go with pre-packed strategy, this prop is required.
+
+If you choose to use auto packing, this prop should be left empty.
+
+See `iconMapping` in [DeckGl IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer).
+
+#### `editHandleIconSizeScale` (Number, optional)
+
+- Default `1`
+
+Edit handle icon size multiplier.
+
+See `sizeScale` in [DeckGl IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer).
+
+#### `getEditHandleIcon` (Function, optional)
+
+- Default: `d => d.icon`
+
+Method called to retrieve the icon name of each edit handle, returns string or object.
+
+If you go with pre-packed strategy, then getIcon should return a string representing name of the icon, used to retrieve icon definition from given iconMapping.
+
+If you choose to use auto packing, then getIcon should return an object which contains the following properties.
+
+- `url` (String, required): url to fetch the icon
+- `height` (Number, required): height of icon
+- `width` (Number, required): width of icon
+- `id`: (String, optional): unique identifier of the icon, fall back to url if not specified
+- `anchorX`, `anchorY`, `mask` are the same as mentioned in iconMapping
+
+`IconLayer` use `id` (fallback to url) to dedupe icons. If for the same icon identifier, getIcon returns different `width` or `height`, `IconLayer` will only apply the first occurrence and ignore the rest of them.
+
+See `getIcon` in [DeckGl IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer).
+
+#### `getEditHandleIconSize` (Function|Number, optional)
+
+- Default `10`
+
+The height of each edit handle icon, in units specified by `sizeUnits` (default pixels).
+
+If a number is provided, it is used as the size for all objects.
+If a function is provided, it is called on each object to retrieve its size.
+
+See `getSize` in [DeckGl IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer).
+
+#### `getEditHandleIconColor` (Function|Array, optional)
+
+- Default: `[0, 0, 0, 255]`
+
+The rgba color is in the format of `[r, g, b, [a]]`. Each channel is a number between 0-255 and `a` is 255 if not supplied.
+
+- If an array is provided, it is used as the color for all objects.
+- If a function is provided, it is called on each object to retrieve its color.
+- If `mask` = false, only the alpha component will be used to control the opacity of the icon.
+
+See `getColor` in [DeckGl IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer).
+
+#### `getEditHandleIconAngle` (Function|Number, optional)
+
+- Default `0`
+
+The rotating angle of each edit handle icon, in degrees.
+
+- If a number is provided, it is used as the angle for all objects.
+- If a function is provided, it is called on each object to retrieve its angle.
+
+See `getAngle` in [DeckGl IconLayer](https://deck.gl/docs/api-reference/layers/icon-layer).
+
+#### `billboard` (Boolean, optional)
+
+- Default: `true`
+
+If on, the edit handle icon always faces camera. Otherwise the icon faces up (z)
 
 ##### Example
 

--- a/docs/api-reference/layers/mesh-layer.md
+++ b/docs/api-reference/layers/mesh-layer.md
@@ -41,7 +41,7 @@ const App = ({ data, viewport }) => {
 ##### `mesh` (Geometry|Object)
 
 The geometry to render for each data object.
-Can be a luma.gl [Geometry](http://uber.github.io/luma.gl/#/documentation/api-reference/geometry) instance, or an object of attributes.
+Can be a luma.gl [Geometry](https://luma.gl/docs/api-reference/engine/geometry) instance, or an object of attributes.
 
 The following attributes are expected:
 
@@ -54,7 +54,7 @@ The following attributes are expected:
 - Default `null`.
 
 The texture of the geometries.
-Can be either a luma.gl [Texture2D](http://uber.github.io/luma.gl/#/documentation/api-reference/texture-2) instance, an HTMLImageElement, or a url string to the texture image.
+Can be either a luma.gl [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d\) instance, an HTMLImageElement, or a url string to the texture image.
 
 If `texture` is supplied, texture is used to render the geometries. Otherwise, object color obtained via the `getColor` accessor is used.
 

--- a/docs/api-reference/layers/selection-layer.md
+++ b/docs/api-reference/layers/selection-layer.md
@@ -65,7 +65,7 @@ const App = function () {
 
 ## Properties
 
-Inherits all [deck.gl's Base Layer](https://uber.github.io/deck.gl/#/documentation/deckgl-api-reference/layers/layer) properties.
+Inherits all [deck.gl's Base Layer](https://deck.gl/docs/api-reference/core/layer) properties.
 
 Also inherites **some** EditableGeoJsonLayer properties.
 

--- a/website/ocular-config.js
+++ b/website/ocular-config.js
@@ -113,7 +113,7 @@ module.exports = {
     {
       name: 'react-map-gl',
       title: 'react-map-gl',
-      url: 'https://uber.github.io/react-map-gl',
+      url: 'https://visgl.github.io/react-map-gl/',
     },
     {
       name: 'react-vis',


### PR DESCRIPTION
Hi, I noticed there were many properties and data setters in the code of EditableGeoJSONLayer that were not in the docs, properties for the the point handles and tentative features like `getTentativeFillColor`. I've added these to the documentation and I've updated all links to DeckGL's website while I was add it.