### PR TITLE
fix(react-map-gl-draw): Fix issue 580 EditingMode drag to move

### DIFF
--- a/modules/react-map-gl-draw/src/mode-handler.tsx
+++ b/modules/react-map-gl-draw/src/mode-handler.tsx
@@ -417,13 +417,11 @@ export default class ModeHandler extends React.PureComponent<EditorProps, Editor
       cancelPan: event.sourceEvent.stopImmediatePropagation,
     };
 
+    const modeProps = this.getModeProps();
+
+    this._modeHandler.handlePointerMove(pointerMoveEvent, modeProps);
     if (this.state.didDrag) {
-      const modeProps = this.getModeProps();
-      if (this._modeHandler.handleDragging) {
-        this._modeHandler.handleDragging(pointerMoveEvent, modeProps);
-      } else {
-        this._modeHandler.handlePointerMove(pointerMoveEvent, modeProps);
-      }
+      this._modeHandler.handleDragging(pointerMoveEvent, modeProps);
     }
 
     this.setState({


### PR DESCRIPTION
Fixed issue with react-map-gl-draw EditingMode where dragging to move an edit handle or a geometry wasn't working. Issue #580 

Fixed by calling`handlePointerMove` even when not dragging.
 - this is in line with the [generic edit mode RFC](https://github.com/uber/nebula.gl/blob/master/dev-docs/RFCs/v1.0/generic-edit-mode.md) which states `handlePointerMove` should be called "regardless of whether the pointer is down, up, and whether something was picked"
 - this is also in line with how nebula gl works with deck gl - `handlePointerMove` is called along with (and not instead of) `handleDragging`






