### PR TITLE
Nearest point on line

### DIFF
--- a/modules/edit-modes/src/lib/modify-mode.ts
+++ b/modules/edit-modes/src/lib/modify-mode.ts
@@ -63,7 +63,7 @@ export class ModifyMode extends GeoJsonEditMode {
           [],
           (lineString, prefix) => {
             const lineStringFeature = toLineString(lineString);
-            const candidateIntermediatePoint = this.nearestPointOnLine(
+            const candidateIntermediatePoint = this.getNearestPoint(
               // @ts-ignore
               lineStringFeature,
               referencePoint,
@@ -108,7 +108,7 @@ export class ModifyMode extends GeoJsonEditMode {
   }
 
   // turf.js does not support elevation for nearestPointOnLine
-  nearestPointOnLine(
+  getNearestPoint(
     line: FeatureOf<LineString>,
     inPoint: FeatureOf<Point>,
     viewport: Viewport | null | undefined

--- a/modules/edit-modes/src/lib/modify-mode.ts
+++ b/modules/edit-modes/src/lib/modify-mode.ts
@@ -1,8 +1,8 @@
-import nearestPointOnLine from '@turf/nearest-point-on-line';
 import { point, lineString as toLineString } from '@turf/helpers';
 import {
   recursivelyTraverseNestedArrays,
   nearestPointOnProjectedLine,
+  nearestPointOnLine,
   getEditHandlesForGeometry,
   getPickedEditHandles,
   getPickedEditHandle,
@@ -124,8 +124,7 @@ export class ModifyMode extends GeoJsonEditMode {
         'Editing 3D point but modeConfig.viewport not provided. Falling back to 2D logic.'
       );
     }
-
-    return nearestPointOnLine(line, inPoint);
+    return nearestPointOnLine(line, inPoint, viewport);
   }
 
   handleClick(event: ClickEvent, props: ModeProps<FeatureCollection>) {

--- a/modules/edit-modes/src/lib/resize-circle-mode.ts
+++ b/modules/edit-modes/src/lib/resize-circle-mode.ts
@@ -62,7 +62,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
           [],
           (lineString, prefix) => {
             const lineStringFeature = toLineString(lineString);
-            const candidateIntermediatePoint = this.nearestPointOnLine(
+            const candidateIntermediatePoint = this.getNearestPoint(
               // @ts-ignore
               lineStringFeature,
               referencePoint,
@@ -107,7 +107,7 @@ export class ResizeCircleMode extends GeoJsonEditMode {
   }
 
   // turf.js does not support elevation for nearestPointOnLine
-  nearestPointOnLine(
+  getNearestPoint(
     line: FeatureOf<LineString>,
     inPoint: FeatureOf<Point>,
     viewport: Viewport | null | undefined

--- a/modules/edit-modes/src/utils.ts
+++ b/modules/edit-modes/src/utils.ts
@@ -192,6 +192,10 @@ export function nearestPointOnLine<G extends LineString | MultiLineString>(
     dist: Infinity,
   });
 
+  if (!lines.geometry?.coordinates.length || lines.geometry?.coordinates.length < 2) {
+    return closestPoint;
+  }
+
   // @ts-ignore
   flattenEach(lines, (line: any) => {
     const coords: any = getCoords(line);

--- a/modules/edit-modes/test/lib/__snapshots__/modify-mode.test.ts.snap
+++ b/modules/edit-modes/test/lib/__snapshots__/modify-mode.test.ts.snap
@@ -762,8 +762,8 @@ exports[`getGuides() includes an intermediate edit handle 1`] = `
 Object {
   "geometry": Object {
     "coordinates": Array [
-      -122.43850292231143,
-      37.777692666558565,
+      -122.4385053241134,
+      37.77770362630828,
     ],
     "type": "Point",
   },

--- a/modules/edit-modes/test/lib/utils.test.ts
+++ b/modules/edit-modes/test/lib/utils.test.ts
@@ -5,6 +5,7 @@ import {
   distance2d,
   mix,
   nearestPointOnProjectedLine,
+  nearestPointOnLine,
 } from '../../src/utils';
 import { Position } from '../../src/geojson-types';
 
@@ -207,6 +208,40 @@ describe('nearestPointOnProjectedLine() and related functions', () => {
     expect(result.geometry.coordinates[0]).toBeCloseTo(0.5, 3);
     expect(result.geometry.coordinates[1]).toBeCloseTo(0.5, 3);
     expect(result.geometry.coordinates[2]).toBeCloseTo(0.5, 3);
+    expect(result.properties.index).toEqual(0);
+  });
+});
+
+describe('nearestPointOnLine()', () => {
+  const viewport = {
+    project: (x) => x,
+    unproject: (x) => x,
+  };
+
+  it('Correctly intersects line normal to slope of line', () => {
+    // @ts-ignore
+    const result = nearestPointOnLine(LineString, Point, viewport);
+    expect(result.geometry.type).toEqual('Point');
+    expect(result.geometry.coordinates.length).toEqual(2);
+    expect(result.geometry.coordinates[0]).toBeCloseTo(102.25, 3);
+    expect(result.geometry.coordinates[1]).toBeCloseTo(0.25, 3);
+    expect(result.properties.index).toEqual(0);
+  });
+
+  it('Snaps to the end when the point is past the end of the LineString', () => {
+    const point = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [100.0, -4.0],
+      },
+    };
+    // @ts-ignore
+    const result = nearestPointOnLine(LineString, point, viewport);
+    expect(result.geometry.type).toEqual('Point');
+    expect(result.geometry.coordinates.length).toEqual(2);
+    expect(result.geometry.coordinates[0]).toBeCloseTo(102.0, 3);
+    expect(result.geometry.coordinates[1]).toBeCloseTo(0.0, 3);
     expect(result.properties.index).toEqual(0);
   });
 });


### PR DESCRIPTION
Addressed issue: https://github.com/Turfjs/turf/issues/1440

@turf/nearest-point-on-line currently does not consistently calculate the closest snapping point. As lines/polygons get larger, the precision is reduced due to different projections that are used for calculations in turf. Since nebula uses Mercator projection, Cartesian geometry should be sufficient. Deviations caused by zoom are addressed by matching points to the pixels in the viewport. If the viewport is not provided, there is slight offset, but is still more accurate than current turf implementations
