### PR TITLE
fix "this.state is null" error

### DIFF
--- a/modules/layers/src/layers/editable-geojson-layer.ts
+++ b/modules/layers/src/layers/editable-geojson-layer.ts
@@ -476,6 +476,11 @@ export default class EditableGeoJsonLayer extends EditableLayer {
   }
 
   getCursor({ isDragging }: { isDragging: boolean }) {
+    if (this.state === null) {
+      // Layer in 'Awaiting state'
+      return;
+    };
+    
     let { cursor } = this.state;
     if (!cursor) {
       // default cursor


### PR DESCRIPTION
When a layer is not yet ready, trying to read its cursor causes the entire layer to fall