### PR TITLE
docs: update snippet to install modules as dev

### DIFF
--- a/docs/get-started/installing.md
+++ b/docs/get-started/installing.md
@@ -1,8 +1,8 @@
 # Installation
 
 ```bash
-yarn add "@nebula.gl/layers"
-yarn add "@nebula.gl/overlays"
+yarn add -D "@nebula.gl/layers"
+yarn add -D "@nebula.gl/overlays"
 ```
 
 nebula.gl will automatically install a compatible version of deck.gl.


### PR DESCRIPTION
Installing Nebula as a devDependency with yarn seems like more common approach.
Most people that need it as a direct dependency probably would use a CDN instead.