### PR TITLE
Remove broken `calculateZLevels`

### DIFF
--- a/modules/layers/src/layers/path-outline-layer/path-outline-layer.ts
+++ b/modules/layers/src/layers/path-outline-layer/path-outline-layer.ts
@@ -61,7 +61,6 @@ export default class PathOutlineLayer<
       instanceZLevel: {
         size: 1,
         type: GL.UNSIGNED_BYTE,
-        update: this.calculateZLevels,
         accessor: 'getZLevel',
       },
     });
@@ -129,17 +128,6 @@ export default class PathOutlineLayer<
       parameters: {
         depthTest: false,
       },
-    });
-  }
-
-  calculateZLevels(attribute) {
-    const { getZLevel } = this.props;
-    const { pathTesselator } = this.state;
-
-    attribute.value = pathTesselator._updateAttribute({
-      target: attribute.value,
-      size: 1,
-      getValue: (object, index) => [getZLevel(object, index) || 0],
     });
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/uber/nebula.gl/issues/532

Starting from https://github.com/visgl/deck.gl/pull/3094 the `update` is optional. If not passed - the accessor will be used. 
See: https://github.com/visgl/deck.gl/blob/master/modules/core/src/lib/attribute/attribute.js#L26