### PR TITLE
fix: link to modes overview

### DIFF
--- a/docs/api-reference/layers/editable-geojson-layer.md
+++ b/docs/api-reference/layers/editable-geojson-layer.md
@@ -67,7 +67,7 @@ _Note: passing a single `Feature` is not supported. However, you can pass a `Fea
 
 The `mode` property defines the mode used to handle user interaction events (e.g. pointer events) in order to accomplish edits. This can either be a constructor for an `EditMode` or an instance of `EditMode`.
 
-There are a extensive number of modes that come out-of-the-box with nebula.gl. See [modes overview](/docs/api-reference/modes/overview.md).
+There are a extensive number of modes that come out-of-the-box with nebula.gl. See [modes overview](../modes/overview.md).
 
 #### `modeConfig` (Object, optional)
 


### PR DESCRIPTION
There are two links on this page to modes overview section, but the first one was broken on the website, so I copied the link from the working one.

If I understand correctly, the link like this should also work on the website: `[modes overview](/docs/api-reference/modes/overview)` (without `.md`), but I checked other links in the repo, and the links with similar format don't work in the GitHub READMEs (only on the website), so I chose the one that should be working in both.