### PR TITLE
Fix overlay jiggling issue when zooming

### DIFF
--- a/modules/overlays/src/html-overlay-item.tsx
+++ b/modules/overlays/src/html-overlay-item.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
 
-const styles = {
-  item: {
-    position: 'absolute',
-    userSelect: 'none',
-  },
-};
-
 type Props = {
   // Injected by HtmlOverlay
   x?: number;
@@ -23,9 +16,10 @@ export default class HtmlOverlayItem extends React.Component<Props> {
     const { x, y, children, style, coordinates, ...props } = this.props;
 
     return (
-      //@ts-ignore
-      <div style={{ ...styles.item, ...style, left: x, top: y }} {...props}>
-        {children}
+      <div style={{ transform: `translate(${x}px, ${y}px)` }}>
+        <div style={{ position: 'absolute', userSelect: 'none', ...style }} {...props}>
+          {children}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Prior to this fix, HTML overlays subtly "jiggle" when zooming in or out. This effect is more noticeable for circular overlay items. The solution I came up with is to use css transform translate instead of using css left/top offsetting.

Before fix:
![zoom_before_fix](https://user-images.githubusercontent.com/42187119/161617044-a491862c-6dbf-46f8-a08b-0a47b3156e31.gif)

After fix:
![zoom_after_fix](https://user-images.githubusercontent.com/42187119/161617099-595a7882-1686-42d6-8488-7f23282dc646.gif)
