### PR TITLE
Fix issue where overlay items ignored z-index

### DIFF
--- a/modules/overlays/src/html-overlay-item.tsx
+++ b/modules/overlays/src/html-overlay-item.tsx
@@ -14,13 +14,14 @@ type Props = {
 export default class HtmlOverlayItem extends React.Component<Props> {
   render() {
     const { x, y, children, style, coordinates, ...props } = this.props;
+    const { zIndex, ...remainingStyle } = style || {};
 
     return (
       // Using transform translate to position overlay items will result in a smooth zooming
       // effect, whereas using the top/left css properties will cause overlay items to
       // jiggle when zooming
-      <div style={{ transform: `translate(${x}px, ${y}px)` }}>
-        <div style={{ position: 'absolute', userSelect: 'none', ...style }} {...props}>
+      <div style={{ transform: `translate(${x}px, ${y}px)`, position: 'absolute', zIndex }}>
+        <div style={{ userSelect: 'none', ...remainingStyle }} {...props}>
           {children}
         </div>
       </div>


### PR DESCRIPTION
This diff fixes a bug introduced by a previous [diff](https://github.com/uber/nebula.gl/pull/747/files#diff-e1dc3f6f987fad6da6bee4154e7b2d5055535ead0d6f2120f90a21ee2b60b8a7R23) of mine where adding a z-index style to HTML overlay items wouldn't take effect.

The bug made it so that the following effect wasn't possible to create:
![z-index](https://user-images.githubusercontent.com/42187119/165225175-02233557-3c97-4495-8da3-e4a09bb9f634.gif)

