### PR TITLE
Set default value to zIndex

### DIFF
--- a/modules/overlays/src/html-overlay-item.tsx
+++ b/modules/overlays/src/html-overlay-item.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default class HtmlOverlayItem extends React.Component<Props> {
   render() {
     const { x, y, children, style, coordinates, ...props } = this.props;
-    const { zIndex, ...remainingStyle } = style || {};
+    const { zIndex = 'auto', ...remainingStyle } = style || {};
 
     return (
       // Using transform translate to position overlay items will result in a smooth zooming


### PR DESCRIPTION
This is a follow-up to https://github.com/uber/nebula.gl/pull/753 
`zIndex` is not required. When it is not passed the value `zIndex: undefined` is passed to the `div`. We need to set the default value explicitly.