### PR TITLE
Improving of feature geometry translation

### DIFF
--- a/modules/edit-modes/src/translateFromCenter.ts
+++ b/modules/edit-modes/src/translateFromCenter.ts
@@ -1,0 +1,40 @@
+import turfCenter from '@turf/center';
+import turfRhumbBearing from '@turf/rhumb-bearing';
+import turfRhumbDistance from '@turf/rhumb-distance';
+import turfRhumbDestination from '@turf/rhumb-destination';
+import type { Position as TurfPosition, Feature as TurfFeature, Geometry as TurfGeometry } from '@turf/helpers';
+import type { AnyCoordinates, Position } from './';
+import { mapCoords } from './utils';
+
+
+// This function takes feature's center, moves it, 
+// and builds new feature around it keeping the proportions
+export function translateFromCenter(
+  feature: TurfFeature<TurfGeometry>,
+  distance: number,
+  direction: number,
+) {
+  const initialCenterPoint = turfCenter(feature as TurfFeature);
+
+
+  const movedCenterPoint = turfRhumbDestination(
+    initialCenterPoint,
+    distance,
+    direction,
+  );
+
+  const movedCoordinates = mapCoords(feature.geometry.coordinates as AnyCoordinates, (coordinate) => {
+
+    const distance = turfRhumbDistance(initialCenterPoint.geometry.coordinates, coordinate as TurfPosition);
+    const direction = turfRhumbBearing(initialCenterPoint.geometry.coordinates, coordinate as TurfPosition);
+
+
+    const movedPosition = turfRhumbDestination(movedCenterPoint.geometry.coordinates, distance, direction)
+      .geometry.coordinates;
+    return movedPosition as Position;
+  })
+
+  feature.geometry.coordinates = movedCoordinates;
+
+  return feature;
+}

--- a/modules/edit-modes/test/translateFromCenter.test.ts
+++ b/modules/edit-modes/test/translateFromCenter.test.ts
@@ -1,0 +1,140 @@
+
+import type { Feature as TurfFeature, Geometry } from '@turf/helpers';
+// I used types from geojson because they're generic and helps me with intellisense
+import type {
+  Feature as GenericFeature,
+  Point,
+  MultiPoint,
+  LineString,
+  Polygon,
+  MultiPolygon,
+} from 'geojson';
+import { translateFromCenter } from '../src/translateFromCenter';
+
+type Feature = TurfFeature<Geometry>;
+
+test('Point coordinates in right format', () => {
+  const feature: GenericFeature<Point> = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+    properties: {},
+  };
+  const result = translateFromCenter(
+    feature as Feature,
+    100,
+    100,
+  ) as GenericFeature<Point>;
+  expect(result.geometry.coordinates).toHaveLength(2);
+});
+
+test('MultiPoint coordinates in right format', () => {
+  const feature: GenericFeature<MultiPoint> = {
+    type: 'Feature',
+    geometry: {
+      type: 'MultiPoint',
+      coordinates: [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+    },
+    properties: {},
+  };
+  const result = translateFromCenter(
+    feature as Feature,
+    100,
+    100,
+  ) as GenericFeature<MultiPoint>;
+  expect(result.geometry.coordinates[0]).toHaveLength(2);
+  expect(result.geometry.coordinates[1]).toHaveLength(2);
+  expect(result.geometry.coordinates[2]).toHaveLength(2);
+});
+
+test('LineString coordinates in right format', () => {
+  const feature: GenericFeature<LineString> = {
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates: [
+        [1, 1],
+        [2, 2],
+      ],
+    },
+    properties: {},
+  };
+  const result = translateFromCenter(
+    feature as Feature,
+    100,
+    100,
+  ) as GenericFeature<LineString>;
+  expect(result.geometry.coordinates[0]).toHaveLength(2);
+  expect(result.geometry.coordinates[1]).toHaveLength(2);
+});
+
+
+test('Polygon coordinates in right format', () => {
+  const feature: GenericFeature<Polygon> = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [0, 1],
+          [2, 2],
+        ],
+      ],
+    },
+    properties: {},
+  };
+  const result = translateFromCenter(
+    feature as Feature,
+    100,
+    100,
+  ) as GenericFeature<Polygon>;
+  expect(result.geometry.coordinates[0][0]).toHaveLength(2);
+  expect(result.geometry.coordinates[0][1]).toHaveLength(2);
+  expect(result.geometry.coordinates[0][2]).toHaveLength(2);
+
+  expect(result.geometry.coordinates[0][3]).toBeUndefined();
+  expect(result.geometry.coordinates[1]).toBeUndefined();
+});
+
+test('Polygon coordinates in right format', () => {
+  const feature: GenericFeature<MultiPolygon> = {
+    type: 'Feature',
+    geometry: {
+      type: 'MultiPolygon',
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [0, 1],
+            [2, 2],
+          ],
+          [
+            [3, 3],
+            [5, 3],
+            [5, 5],
+          ],
+        ],
+      ],
+    },
+    properties: {},
+  };
+  const result = translateFromCenter(
+    feature as Feature,
+    100,
+    100,
+  ) as GenericFeature<MultiPolygon>;
+  expect(result.geometry.coordinates[0][0][0]).toHaveLength(2);
+  expect(result.geometry.coordinates[0][0][1]).toHaveLength(2);
+  expect(result.geometry.coordinates[0][0][2]).toHaveLength(2);
+  expect(result.geometry.coordinates[0][1][2]).toHaveLength(2);
+
+  expect(result.geometry.coordinates[0][1][3]).toBeUndefined();
+  expect(result.geometry.coordinates[0][2]).toBeUndefined();
+});


### PR DESCRIPTION
To translate features Nebula used turf `transfromTranslate` function for each point of feature. When applied to polygons this could've create a huge shape distortion
![image](https://user-images.githubusercontent.com/50058726/175909294-9e9f6689-049e-42aa-9621-f85977888206.png)
![image](https://user-images.githubusercontent.com/50058726/175909385-26dfe661-3ccc-4260-bfa4-192e0cd63331.png)
![image](https://user-images.githubusercontent.com/50058726/175909450-38ef50fd-be10-4c6c-8e0d-d906330e58f7.png)

This approach helps to avoid such effect by first moving center point (with same function as turf/transformTranslate uses), and then building new geometry around new center point saving geometry proportions

Before:
![image](https://user-images.githubusercontent.com/50058726/175910502-f6351ac2-2a73-4bf0-af98-249091c71d94.png)
After:
![image](https://user-images.githubusercontent.com/50058726/175910662-f737390a-df18-4d4c-b519-392577e67e2b.png)
