### PR TITLE
Handle escape hotkey in linestring and polygon modes

### DIFF
--- a/modules/edit-modes/src/lib/draw-line-string-mode.ts
+++ b/modules/edit-modes/src/lib/draw-line-string-mode.ts
@@ -47,6 +47,7 @@ export class DrawLineStringMode extends GeoJsonEditMode {
       });
     }
   }
+  
   handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>) {
     const { key } = event;
     if (key === 'Enter') {
@@ -62,8 +63,17 @@ export class DrawLineStringMode extends GeoJsonEditMode {
           props.onEdit(editAction);
         }
       }
+    } else if (key === 'Escape') {
+      this.resetClickSequence();
+      props.onEdit({
+        // Because the new drawing feature is dropped, so the data will keep as the same.
+        updatedData: props.data,
+        editType: 'cancelFeature',
+        editContext: {},
+      });
     }
   }
+
   getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection {
     const { lastPointerMoveEvent } = props;
     const clickSequence = this.getClickSequence();

--- a/modules/edit-modes/src/lib/draw-polygon-by-dragging-mode.ts
+++ b/modules/edit-modes/src/lib/draw-polygon-by-dragging-mode.ts
@@ -44,13 +44,12 @@ export class DrawPolygonByDraggingMode extends DrawPolygonMode {
         coordinates: [[...clickSequence, clickSequence[0]]],
       };
 
-      this.resetClickSequence();
-
       const editAction = this.getAddFeatureOrBooleanPolygonAction(polygonToAdd, props);
       if (editAction) {
         props.onEdit(editAction);
       }
     }
+    this.resetClickSequence();
   }
 
   handleDraggingAux(event: DraggingEvent, props: ModeProps<FeatureCollection>) {
@@ -66,6 +65,37 @@ export class DrawPolygonByDraggingMode extends DrawPolygonMode {
   handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>) {
     if (this.handleDraggingThrottled) {
       this.handleDraggingThrottled(event, props);
+    }
+  }
+
+  handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>) {
+    if (event.key === 'Enter') {
+      const clickSequence = this.getClickSequence();
+      if (clickSequence.length > 2) {
+        const polygonToAdd: Polygon = {
+          type: 'Polygon',
+          coordinates: [[...clickSequence, clickSequence[0]]],
+        };
+        this.resetClickSequence();
+
+        const editAction = this.getAddFeatureOrBooleanPolygonAction(polygonToAdd, props);
+        if (editAction) {
+          props.onEdit(editAction);
+        }
+      }
+    } else if (event.key === 'Escape') {
+      this.resetClickSequence();
+      // @ts-ignore
+      if (this.handleDraggingThrottled) {
+        // @ts-ignore
+        this.handleDraggingThrottled = null;
+      }
+      props.onEdit({
+        // Because the new drawing feature is dropped, so the data will keep as the same.
+        updatedData: props.data,
+        editType: 'cancelFeature',
+        editContext: {},
+      });
     }
   }
 }

--- a/modules/edit-modes/src/lib/draw-polygon-mode.ts
+++ b/modules/edit-modes/src/lib/draw-polygon-mode.ts
@@ -152,6 +152,14 @@ export class DrawPolygonMode extends GeoJsonEditMode {
           props.onEdit(editAction);
         }
       }
+    } else if (event.key === 'Escape') {
+      this.resetClickSequence();
+      props.onEdit({
+        // Because the new drawing feature is dropped, so the data will keep as the same.
+        updatedData: props.data,
+        editType: 'cancelFeature',
+        editContext: {},
+      });
     }
   }
 

--- a/modules/edit-modes/src/lib/geojson-edit-mode.ts
+++ b/modules/edit-modes/src/lib/geojson-edit-mode.ts
@@ -259,17 +259,7 @@ export class GeoJsonEditMode implements EditMode<FeatureCollection, GuideFeature
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>): void {}
   handleDragging(event: DraggingEvent, props: ModeProps<FeatureCollection>): void {}
 
-  handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>): void {
-    if (event.key === 'Escape') {
-      this.resetClickSequence();
-      props.onEdit({
-        // Because the new drawing feature is dropped, so the data will keep as the same.
-        updatedData: props.data,
-        editType: 'cancelFeature',
-        editContext: {},
-      });
-    }
-  }
+  handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>): void {}
 }
 
 export function getIntermediatePosition(position1: Position, position2: Position): Position {

--- a/modules/edit-modes/test/lib/draw-line-string-mode.test.ts
+++ b/modules/edit-modes/test/lib/draw-line-string-mode.test.ts
@@ -1,12 +1,13 @@
 /* eslint-env jest */
 
 import { DrawLineStringMode } from '../../src/lib/draw-line-string-mode';
-import { createFeatureCollectionProps, createClickEvent } from '../test-utils';
+import { createFeatureCollectionProps, createClickEvent, createKeyboardEvent } from '../test-utils';
 
 let props;
+let mode;
 
-beforeAll(() => {
-  const mode = new DrawLineStringMode();
+beforeEach(() => {
+  mode = new DrawLineStringMode();
   props = createFeatureCollectionProps({
     data: {
       type: 'FeatureCollection',
@@ -17,30 +18,11 @@ beforeAll(() => {
   mode.handleClick(createClickEvent([1, 2]), props);
   mode.handleClick(createClickEvent([3, 4]), props);
   mode.handleClick(createClickEvent([5, 6]), props);
-
-  mode.handleClick(
-    createClickEvent(
-      [5.0000001, 6.0000001],
-      [
-        {
-          index: -1,
-          isGuide: true,
-          object: {
-            properties: {
-              guideType: 'editHandle',
-              positionIndexes: [2],
-            },
-          },
-        },
-      ]
-    ),
-    props
-  );
 });
 
 describe('while tentative', () => {
   it('calls onEdit', () => {
-    expect(props.onEdit).toHaveBeenCalledTimes(4);
+    expect(props.onEdit).toHaveBeenCalledTimes(3);
 
     expect(props.onEdit.mock.calls[0][0].editType).toEqual('addTentativePosition');
     expect(props.onEdit.mock.calls[0][0].editContext.position).toEqual([1, 2]);
@@ -63,7 +45,28 @@ describe('while tentative', () => {
 });
 
 describe('after double-clicking', () => {
+  beforeEach(() => {
+    mode.handleClick(
+      createClickEvent(
+        [5.0000001, 6.0000001],
+        [
+          {
+            index: -1,
+            isGuide: true,
+            object: {
+              properties: {
+                guideType: 'editHandle',
+                positionIndexes: [2],
+              },
+            },
+          },
+        ]
+      ),
+      props
+    );
+  });
   it('calls onEdit with an added feature', () => {
+    expect(props.onEdit).toHaveBeenCalledTimes(4);
     expect(props.onEdit.mock.calls[3][0].editType).toEqual('addFeature');
     expect(props.onEdit.mock.calls[3][0].updatedData.features).toEqual([
       {
@@ -79,5 +82,52 @@ describe('after double-clicking', () => {
         },
       },
     ]);
+  });
+});
+
+describe('after hitting enter', () => {
+  beforeEach(() => {
+    mode.handleKeyUp(createKeyboardEvent('Enter'), props);
+  });
+  it('calls onEdit with an added feature', () => {
+    expect(props.onEdit).toHaveBeenCalledTimes(4);
+    expect(props.onEdit.mock.calls[3][0].editType).toEqual('addFeature');
+    expect(props.onEdit.mock.calls[3][0].updatedData.features).toEqual([
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'LineString',
+          coordinates: [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+        },
+      },
+    ]);
+  });
+});
+
+describe('after hitting escape', () => {
+  beforeEach(() => {
+    mode.handleKeyUp(createKeyboardEvent('Escape'), props);
+  });
+
+  it('calls onEdit with cancelFeature', () => {
+    expect(props.onEdit).toHaveBeenCalledTimes(4);
+    expect(props.onEdit.mock.calls[3][0].editType).toEqual('cancelFeature');
+  });
+
+  it(`doesn't change the data`, () => {
+    const expectedData = {
+      type: 'FeatureCollection',
+      features: [],
+    };
+    expect(props.onEdit.mock.calls[3][0].updatedData).toEqual(expectedData);
+  });
+
+  it(`resets the click sequence`, () => {
+    expect(mode.getClickSequence()).toEqual([]);
   });
 });

--- a/modules/edit-modes/test/lib/draw-polygon-mode.test.ts
+++ b/modules/edit-modes/test/lib/draw-polygon-mode.test.ts
@@ -1,0 +1,115 @@
+/* eslint-env jest */
+
+import { DrawPolygonMode } from '../../src/lib/draw-polygon-mode';
+import { createFeatureCollectionProps, createClickEvent, createKeyboardEvent } from '../test-utils';
+
+let props;
+let mode;
+
+beforeEach(() => {
+  mode = new DrawPolygonMode();
+  props = createFeatureCollectionProps({
+    data: {
+      type: 'FeatureCollection',
+      features: [],
+    },
+  });
+
+  mode.handleClick(createClickEvent([0, 2]), props);
+  mode.handleClick(createClickEvent([2, 2]), props);
+  mode.handleClick(createClickEvent([2, 0]), props);
+});
+
+describe('after double-clicking', () => {
+  beforeEach(() => {
+    mode.handleClick(
+      createClickEvent(
+        [-1, -1],
+        [
+          {
+            index: -1,
+            isGuide: true,
+            object: {
+              properties: {
+                guideType: 'editHandle',
+                positionIndexes: [2],
+              },
+            },
+          },
+        ]
+      ),
+      props
+    );
+  });
+  it('calls onEdit with an added feature', () => {
+    expect(props.onEdit).toHaveBeenCalledTimes(4);
+    expect(props.onEdit.mock.calls[3][0].editType).toEqual('addFeature');
+    expect(props.onEdit.mock.calls[3][0].updatedData.features).toEqual([
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 2],
+              [2, 0],
+              [2, 2],
+              [0, 2],
+            ],
+          ],
+        },
+      },
+    ]);
+  });
+});
+
+describe('after hitting enter', () => {
+  beforeEach(() => {
+    mode.handleKeyUp(createKeyboardEvent('Enter'), props);
+  });
+  it('calls onEdit with an added feature', () => {
+    expect(props.onEdit).toHaveBeenCalledTimes(4);
+    expect(props.onEdit.mock.calls[3][0].editType).toEqual('addFeature');
+    expect(props.onEdit.mock.calls[3][0].updatedData.features).toEqual([
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 2],
+              [2, 0],
+              [2, 2],
+              [0, 2],
+            ],
+          ],
+        },
+      },
+    ]);
+  });
+});
+
+describe('after hitting escape', () => {
+  beforeEach(() => {
+    mode.handleKeyUp(createKeyboardEvent('Escape'), props);
+  });
+
+  it('calls onEdit with cancelFeature', () => {
+    expect(props.onEdit).toHaveBeenCalledTimes(4);
+    expect(props.onEdit.mock.calls[3][0].editType).toEqual('cancelFeature');
+  });
+
+  it(`doesn't change the data`, () => {
+    const expectedData = {
+      type: 'FeatureCollection',
+      features: [],
+    };
+    expect(props.onEdit.mock.calls[3][0].updatedData).toEqual(expectedData);
+  });
+
+  it(`resets the click sequence`, () => {
+    expect(mode.getClickSequence()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #773

Moves handling of keyup.escape to DrawLineStringMode, DrawPolygonMode, and DrawPolygonByDraggingMode.  In dragging mode, escape also halts the dragging handler, so no new points are added until a new click.

Also adds some hotkey tests.