### PR TITLE
Make DrawPolygonByDraggingMode fire addTentativePosition events

### DIFF
--- a/modules/edit-modes/src/lib/draw-polygon-by-dragging-mode.ts
+++ b/modules/edit-modes/src/lib/draw-polygon-by-dragging-mode.ts
@@ -60,6 +60,13 @@ export class DrawPolygonByDraggingMode extends DrawPolygonMode {
     if (!clickedEditHandle) {
       // Don't add another point right next to an existing one.
       this.addClickSequence(event);
+      props.onEdit({
+        updatedData: props.data,
+        editType: 'addTentativePosition',
+        editContext: {
+          position: event.mapCoords,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
Brings DrawPolygonByDraggingMode into line with DrawPolygonMode, firing an addTentativePosition event whenever a position is added