### PR TITLE
prevent onEdit callback on MeasureAreaMode keyup

### DIFF
--- a/modules/edit-modes/src/lib/measure-area-mode.ts
+++ b/modules/edit-modes/src/lib/measure-area-mode.ts
@@ -17,6 +17,16 @@ export class MeasureAreaMode extends DrawPolygonMode {
     super.handleClick(event, propsWithoutEdit);
   }
 
+  handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>): void {
+    const propsWithoutEdit = {
+      ...props,
+      // @ts-ignore
+      onEdit: () => {},
+    };
+
+    super.handleKeyUp(event, propsWithoutEdit);
+  }
+
   getTooltips(props: ModeProps<FeatureCollection>): Tooltip[] {
     const tentativeGuide = this.getTentativeGuide(props);
 

--- a/modules/edit-modes/test/lib/measure-area-mode.test.ts
+++ b/modules/edit-modes/test/lib/measure-area-mode.test.ts
@@ -5,6 +5,7 @@ import {
   createFeatureCollectionProps,
   createClickEvent,
   createPointerMoveEvent,
+  createKeyboardEvent,
 } from '../test-utils';
 
 describe('move without click', () => {
@@ -62,5 +63,66 @@ describe('three clicks + pointer move', () => {
       modeConfig: { formatTooltip: (area) => String(Math.round(area)) },
     });
     expect(tooltips[0].text).toEqual('49565599608');
+  });
+});
+
+describe('finished drawing by clicking', () => {
+  let mode: MeasureAreaMode;
+  let props;
+
+  beforeEach(() => {
+    mode = new MeasureAreaMode();
+    props = createFeatureCollectionProps();
+    mode.handleClick(createClickEvent([1, 1]), props);
+    mode.handleClick(createClickEvent([-1, 1]), props);
+    mode.handleClick(createClickEvent([-1, -1]), props);
+    mode.handleClick(
+      createClickEvent(
+        [-1, -1],
+        [
+          {
+            index: -1,
+            isGuide: true,
+            object: {
+              properties: {
+                guideType: 'editHandle',
+                positionIndexes: [2],
+              },
+            },
+          },
+        ]
+      ),
+      props
+    );
+  });
+
+  it('the click sequence should be cleared', () => {
+    expect(mode.getClickSequence()).toEqual([]);
+  });
+
+  it('onEdit should not be callled', () => {
+    expect(props.onEdit).not.toBeCalled();
+  });
+});
+
+describe('finished drawing by pressing enter', () => {
+  let mode: MeasureAreaMode;
+  let props;
+
+  beforeEach(() => {
+    mode = new MeasureAreaMode();
+    props = createFeatureCollectionProps();
+    mode.handleClick(createClickEvent([1, 1]), props);
+    mode.handleClick(createClickEvent([-1, 1]), props);
+    mode.handleClick(createClickEvent([-1, -1]), props);
+    mode.handleKeyUp(createKeyboardEvent('Enter'), props);
+  });
+
+  it('the click sequence should be cleared', () => {
+    expect(mode.getClickSequence()).toEqual([]);
+  });
+
+  it('onEdit should not be callled', () => {
+    expect(props.onEdit).not.toBeCalled();
   });
 });


### PR DESCRIPTION
Prevents an 'Enter' keypress from calling the noEdit callback when using MeasureAreaMode (just as it's prevented for mouse clicks).  Also adds tests to cover both the keypress and mouse cases.