### PR TITLE
fix: Fix to fire the finishMovePosition state at the end of a feature…

### DIFF
--- a/modules/react-map-gl-draw/src/edit-modes/editing-mode.ts
+++ b/modules/react-map-gl-draw/src/edit-modes/editing-mode.ts
@@ -73,12 +73,12 @@ export default class EditingMode extends BaseMode {
     const picked = event.picks && event.picks[0];
 
     // @ts-ignore
-    if (!picked || !picked.Object || !isNumeric(picked.featureIndex)) {
+    if (!picked || !picked.object || !isNumeric(picked.featureIndex)) {
       return;
     }
 
     const pickedObject = picked.object;
-    switch (pickedObject.type) {
+    switch (pickedObject.type.toLowerCase()) {
       case ELEMENT_TYPE.FEATURE:
       case ELEMENT_TYPE.FILL:
       case ELEMENT_TYPE.EDIT_HANDLE:


### PR DESCRIPTION
During the editing mode, the state called finishMovePosition is never fired, I found out that the problem was derived by a mistyped call to an object property and to a comparison between strings, in particular with the constant ELEMENT_TYPE.FEATURE that in my case has a capital letter differently from what is defined in the code, for this reason, I added a call to toLowerCase function to the switch because of the many places where the constant is used.