### PR TITLE
Prevent altering geometry on map drag end

### DIFF
--- a/modules/edit-modes/src/lib/modify-mode.ts
+++ b/modules/edit-modes/src/lib/modify-mode.ts
@@ -273,7 +273,7 @@ export class ModifyMode extends GeoJsonEditMode {
 
   handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
     const selectedFeatureIndexes = props.selectedIndexes;
-    const editHandle = getPickedEditHandle(event.picks);
+    const editHandle = getPickedEditHandle(event.pointerDownPicks);
     if (selectedFeatureIndexes.length && editHandle) {
       this._dragEditHandle('finishMovePosition', props, editHandle, event);
     }


### PR DESCRIPTION
When in `ModifyMode`, if you end dragging the map close enough to a selected LineString that a tentative handle appears, the nearest vertex is replaced with that point:

[modify-on-drag-end.webm](https://user-images.githubusercontent.com/10194397/215506407-63426ccf-d717-4922-bd60-02900e7db0f3.webm)

This fixes it by relying on the `pointerDownPicks` like `handleDragging`.   