### PR TITLE
Correct onEdit typing

### DIFF
--- a/modules/layers/src/layers/editable-geojson-layer.ts
+++ b/modules/layers/src/layers/editable-geojson-layer.ts
@@ -111,7 +111,7 @@ export type EditableGeojsonLayerProps<DataT = any> = EditableLayerProps<DataT> &
   mode?: any;
   modeConfig?: any;
   selectedFeatureIndexes?: number[];
-  onEdit?: (updatedData?, editType?: string, featureIndexes?: number[], editContext?) => void;
+  onEdit?: (editAction: EditAction<DataT>) => void;
 
   pickable?: boolean;
   pickingRadius?: number;

--- a/modules/layers/src/layers/editable-h3-cluster-layer.ts
+++ b/modules/layers/src/layers/editable-h3-cluster-layer.ts
@@ -2,7 +2,7 @@
 
 import { H3ClusterLayer } from '@deck.gl/geo-layers';
 import { DefaultProps } from '@deck.gl/core/typed';
-import { ViewMode } from '@nebula.gl/edit-modes';
+import { EditAction, ViewMode } from '@nebula.gl/edit-modes';
 import { polyfill, geoToH3 } from 'h3-js';
 import { PROJECTED_PIXEL_SIZE_MULTIPLIER } from '../constants';
 import EditableGeoJsonLayer from './editable-geojson-layer';
@@ -22,7 +22,7 @@ export type EditableH3ClusterLayerProps<DataT> = EditableLayerProps<DataT> & {
   selectedIndexes?: number[];
   getEditedCluster?: (updatedHexagons: any[], existingCluster: any) => any;
   getHexagons?: (d) => number[];
-  onEdit?: (updatedData?, editType?: string, featureIndexes?: number[], editContext?) => void;
+  onEdit?: (editAction: EditAction<DataT>) => void;
   filled?: boolean;
   stroked?: boolean;
   lineWidthScale?: number;


### PR DESCRIPTION
Brings it into line with how it's actually used: https://github.com/uber/nebula.gl/blob/a3f81bb6476b36a34a20359c97046c3a75b3ecdd/modules/edit-modes/src/types.ts#L129
https://github.com/uber/nebula.gl/blob/2a962399ef7c45c1bda8ddb34394becb04a08995/modules/layers/src/layers/editable-geojson-layer.ts#L413